### PR TITLE
JSDK-1503 RTCSessionDescription's properties are now read-only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.0.1 (in progress)
+==================
+
+Bug Fixes
+---------
+
+- `RTCSessionDescription` properties are now read-only, and therefore standards-compliant. (JSDK-1503)  
+
 1.0.0 (August 17, 2017)
 =======================
 

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -213,8 +213,10 @@ ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {
   var self = this;
 
   var promise = this._peerConnection.createOffer(options).then(function(offer) {
-    offer.sdp = updateTracksToSSRCs(self._tracksToSSRCs, offer.sdp);
-    return offer;
+    return new ChromeRTCSessionDescription({
+      type: offer.type,
+      sdp: updateTracksToSSRCs(self._tracksToSSRCs, offer.sdp)
+    });
   });
 
   return args.length > 1

--- a/lib/rtcpeerconnection/safari.js
+++ b/lib/rtcpeerconnection/safari.js
@@ -228,8 +228,10 @@ SafariRTCPeerConnection.prototype.createOffer = function createOffer(options) {
   }
 
   return this._peerConnection.createOffer(options).then(function(offer) {
-    offer.sdp = updateTracksToSSRCs(self._tracksToSSRCs, offer.sdp);
-    return offer;
+    return new RTCSessionDescription({
+      type: offer.type,
+      sdp: updateTracksToSSRCs(self._tracksToSSRCs, offer.sdp)
+    });
   });
 };
 

--- a/lib/rtcsessiondescription/chrome.js
+++ b/lib/rtcsessiondescription/chrome.js
@@ -19,55 +19,19 @@ function ChromeRTCSessionDescription(descriptionInitDict) {
     ? null
     : new RTCSessionDescription(descriptionInitDict);
 
-  var type = description ? null : 'rollback';
-  var sdp = descriptionInitDict.sdp;
-
   Object.defineProperties(this, {
     _description: {
       get: function() {
         return description;
       }
     },
-    // The .sdp property of an RTCSessionDescription can be updated. If we have
-    // an underlying RTCSessionDescription, update that with a setter. (If not,
-    // the user is able to set a property on the ChromeRTCSessionDescription
-    // directly.)
     sdp: {
       enumerable: true,
-      get: function() {
-        return description ? description.sdp : sdp;
-      },
-      set: function(_sdp) {
-        if (description) {
-          description.sdp = _sdp;
-          return;
-        }
-        sdp = _sdp;
-      }
+      value: description ? description.sdp : descriptionInitDict.sdp
     },
-    // The .type property of an RTCSessionDescription can be updated. If we have
-    // an underlying RTCSessionDescription, update that with the setter. If not,
-    // just update a type variable.
     type: {
       enumerable: true,
-      get: function() {
-        return description ? description.type : type;
-      },
-      set: function(_type) {
-        if (_type === 'rollback' && description) {
-          var sdp = description.sdp;
-          description = null;
-          this.sdp = sdp;
-        } else if (description) {
-          description.type = _type;
-          return;
-        } else if (['offer', 'answer', 'pranswer', 'rollback'].indexOf(_type) === -1) {
-          // Chrome will reject setting .type to an invalid RTCSdpType. We
-          // emulate that here, adding support for "rollback".
-          return;
-        }
-        type = _type;
-      }
+      value: description ? description.type : descriptionInitDict.type
     }
   });
 }

--- a/test/integration/spec/rtcsessiondescription.js
+++ b/test/integration/spec/rtcsessiondescription.js
@@ -17,7 +17,6 @@ describe('RTCSessionDescription', () => {
 
     context('called with an invalid .type', () => {
       var descriptionInitDict = { type: 'bogus' };
-
       testErrorMessages('throws the same error as RTCSessionDescription',
         () => new RTCSessionDescription(descriptionInitDict),
         () => new SessionDescription(descriptionInitDict));
@@ -65,7 +64,6 @@ describe('RTCSessionDescription', () => {
         });
 
         testConstructor();
-
         testRollback(sdp);
       });
     });
@@ -93,79 +91,6 @@ describe('RTCSessionDescription', () => {
       it('sets .type to "rollback"', () => {
         assert.equal(description.type, 'rollback');
       });
-
-      (isSafari ? context.skip : context)
-      ('setting .sdp', () => {
-        var newSdp = 'new fake sdp';
-
-        beforeEach(() => {
-          description.sdp = newSdp;
-        });
-
-        it('sets .sdp', () => {
-          assert.equal(description.sdp, newSdp);
-        });
-
-        it('unwraps to null', () => {
-          assert.equal(unwrap(description), null);
-        });
-      });
-
-      (isSafari ? context.skip : context)
-      ('setting .type to', () => {
-        combinationContext([
-          [
-            ['offer', 'answer', 'pranswer', 'rollback'],
-            x => `"${x}"`
-          ]
-        ], ([newType]) => {
-          beforeEach(() => {
-            description.type = newType;
-          });
-
-          it('does not update .sdp', () => {
-            if (!sdp) {
-              if (description.sdp === '') {
-                return;
-              }
-            }
-            assert.equal(description.sdp, sdp);
-          });
-
-          it('sets .type', () => {
-            assert.equal(description.type, newType);
-          });
-
-          it('unwraps to null', () => {
-            assert.equal(unwrap(description), null);
-          });
-        });
-
-        context('an invalid type', () => {
-          var newType = 'bogus';
-
-          beforeEach(() => {
-            description.type = newType;
-          });
-
-          it('does not update .sdp', () => {
-            if (!sdp) {
-              if (description.sdp === '') {
-                return;
-              }
-            }
-            assert.equal(description.sdp, sdp);
-          });
-
-          it('does not set .type', () => {
-            assert.equal(description.type, 'rollback');
-          });
-
-          it('unwraps to null', () => {
-            assert.equal(unwrap(description), null);
-          });
-        });
-      });
     }
 
     combinationContext([
@@ -191,15 +116,10 @@ describe('RTCSessionDescription', () => {
       });
 
       testConstructor();
-
       testRTCSessionDescription(type, hasSdp ? sdp : null);
     });
 
     function testRTCSessionDescription(type, sdp) {
-      // it('sets ._description to an instance of RTCSessionDescription', () => {
-      //   assert(unwrap(description) instanceof RTCSessionDescription);
-      // });
-
       if (sdp) {
         it('sets .sdp', () => {
           assert.equal(description.sdp, sdp);
@@ -221,102 +141,6 @@ describe('RTCSessionDescription', () => {
           assert.equal(unwrap(description).type, description.type);
         });
       }
-
-      (isSafari ? context.skip : context)
-      ('setting .sdp', () => {
-        var newSdp = 'new fake sdp';
-
-        beforeEach(() => {
-          description.sdp = newSdp;
-        });
-
-        it('sets .sdp', () => {
-          assert.equal(description.sdp, newSdp);
-        });
-
-        if (SessionDescription === ChromeRTCSessionDescription) {
-          it('sets .sdp on the unwrapped RTCSessionDescription', () => {
-            assert.equal(unwrap(description).sdp, newSdp);
-          });
-        }
-      });
-
-      (isSafari ? context.skip : context)
-      ('setting .type to', () => {
-        combinationContext([
-          [
-            ['offer', 'answer', 'pranswer'],
-            x => `"${x}"`
-          ]
-        ], ([newType]) => {
-          beforeEach(() => {
-            description.type = newType;
-          });
-
-          it('does not update .sdp', () => {
-            if (description.sdp === '') {
-              return;
-            }
-            assert.equal(description.sdp, sdp);
-          });
-
-          it('sets .type', () => {
-            assert.equal(description.type, newType);
-          });
-
-          if (SessionDescription === ChromeRTCSessionDescription) {
-            it('sets .type on the unwrapped RTCSessionDescription', () => {
-              assert.equal(unwrap(description).type, newType);
-            });
-          }
-        });
-
-        context('"rollback"', () => {
-          var newType = 'rollback';
-
-          beforeEach(() => {
-            description.type = newType;
-          });
-
-          it('unwraps to null', () => {
-            assert.equal(unwrap(description), null);
-          });
-
-          it('does not update .sdp', () => {
-            if (description.sdp === '') {
-              return;
-            }
-            assert.equal(description.sdp, sdp);
-          });
-
-          it('sets .type', () => {
-            assert.equal(description.type, newType);
-          });
-        });
-
-        context('an invalid type', () => {
-          beforeEach(() => {
-            description.type = 'bogus';
-          });
-
-          it('does not update .sdp', () => {
-            if (description.sdp === '') {
-              return;
-            }
-            assert.equal(description.sdp, sdp);
-          });
-
-          it('does not update .type', () => {
-            assert.equal(description.type, type);
-          });
-
-          if (SessionDescription === ChromeRTCSessionDescription) {
-            it('does not set .type on the unwrapped RTCSessionDescription', () => {
-              assert.equal(unwrap(description).type, type);
-            });
-          }
-        });
-      });
     }
   });
 });


### PR DESCRIPTION
@markandrus 

Continuing from here: https://github.com/manjeshbhargav/twilio-webrtc.js/pull/1

Fixed the tests.