### PR TITLE
Adding Karma Chrome launcher for WebRTC 1.0 (addTrack/removeTrack).

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ browsers.
   remapping the legacy property `maxRetransmitTime` to `maxPacketLifeTime`. See
   [this bug](https://bugs.chromium.org/p/chromium/issues/detail?id=696681) for
   more information.
+* Does not depend on the native "track" event (currently behind the flag: `--enable-blink-features=RTCRtpSender`) because
+  of [this bug](https://bugs.chromium.org/p/chromium/issues/detail?id=774303), which partly refers to "ontrack" not firing when expected.
+  We have filed [this bug](https://bugs.chromium.org/p/chromium/issues/detail?id=783433) specifically for this.
 
 #### Firefox
 * For new offers, adds support for calling `setLocalDescription` and `setRemoteDescription` in

--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -18,7 +18,7 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
     }, {});
 
     let browsers = {
-      chrome: ['ChromeWebRTC'],
+      chrome: ['ChromeWebRTC', 'ChromeWebRTC_1_0'],
       firefox: ['FirefoxWebRTC'],
       safari: ['SafariTechPreview']
     };
@@ -29,9 +29,9 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
         throw new Error('Unknown browser');
       }
     } else if (process.platform === 'darwin') {
-      browsers = ['ChromeWebRTC', 'FirefoxWebRTC', 'SafariTechPreview'];
+      browsers = ['ChromeWebRTC', 'ChromeWebRTC_1_0', 'FirefoxWebRTC', 'SafariTechPreview'];
     } else {
-      browsers = ['ChromeWebRTC', 'FirefoxWebRTC'];
+      browsers = ['ChromeWebRTC', 'ChromeWebRTC_1_0', 'FirefoxWebRTC'];
     }
 
     config.set({
@@ -64,6 +64,14 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
           flags: [
             '--use-fake-device-for-media-stream',
             '--use-fake-ui-for-media-stream'
+          ]
+        },
+        ChromeWebRTC_1_0: {
+          base: 'Chrome',
+          flags: [
+            '--use-fake-device-for-media-stream',
+            '--use-fake-ui-for-media-stream',
+            '--enable-blink-features=RTCRtpSender'
           ]
         },
         FirefoxWebRTC: {

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -38,6 +38,13 @@ function ChromeRTCPeerConnection(configuration) {
   util.interceptEvent(this, 'datachannel');
   util.interceptEvent(this, 'signalingstatechange');
 
+  // NOTE(mmalavalli): Because of a bug related to "ontrack", we prevent it
+  // from being delegated to ChromeRTCPeerConnection. For now, this bug
+  // manifests when we run Chrome with the flag: --enable-blink-features=RTCRtpSender
+  // Existing bug: https://bugs.chromium.org/p/chromium/issues/detail?id=774303
+  // Bug filed by us: https://bugs.chromium.org/p/chromium/issues/detail?id=783433
+  util.interceptEvent(this, 'track');
+
   /* eslint new-cap:0 */
   var peerConnection = new PeerConnection(newConfiguration);
 
@@ -248,10 +255,6 @@ util.delegateMethods(
 // for the unreliable MediaStreamTrack#addtrack event. Do this only if
 // the native RTCPeerConnection has not implemented 'ontrack'.
 function maybeDispatchTrackEvents(peerConnection, mediaStreamTracks) {
-  if ('ontrack' in PeerConnection.prototype) {
-    return;
-  }
-
   var currentMediaStreamTracks = util.flatMap(peerConnection.getRemoteStreams(), function(mediaStream) {
     return mediaStream.getTracks();
   });

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "rimraf": "^2.6.1",
     "travis-multirunner": "^4.2.3",
     "watchify": "^3.9.0",
-    "webrtc-adapter": "^5.0.3"
+    "webrtc-adapter": "^5.0.6"
   }
 }


### PR DESCRIPTION
@markandrus 

This PR contains changes to accommodate `addTrack/removeTrack/ontrack`. A new Karma Chrome launcher has been added with the flag `--enable-blink-features=RTCRtpSender`.

I had to bump up the minimum version of `webrtc-adapter` to `5.0.6` as there were some bugs in `5.0.3` in its `addTrack` shim which was causing our tests to fail.