### PR TITLE
Active RTCIceCandidate pair stats.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+2.0.1 (In progress)
+===================
+
+New Features
+------------
+
+- `StandardizedStatsResponse` has a new property `.activeIceCandidatePair`,
+  which contains the normalized active ICE candidate pair statistics.
+
 2.0.0 (January 9, 2018)
 =======================
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ const {
 
 ### getStats
 
-`getStats` resolves with normalized WebRTC statistics for each
-`MediaStreamTrack`, local or remote, of a particular `RTCPeerConnection`.
+`getStats` resolves with normalized WebRTC statistics for the active ICE
+candidate pair and each `MediaStreamTrack`, local or remote, of a particular
+`RTCPeerConnection`.
 
 ```javascript
 /**

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -53,7 +53,7 @@ function _getStats(peerConnection, options) {
   });
 
   return Promise.all(trackStatsPromises).then(function() {
-    return getActiveIceCandidatePairStats(peerConnection);
+    return getActiveIceCandidatePairStats(peerConnection, options);
   }).then(function(activeIceCandidatePairStatsReport) {
     statsResponse.activeIceCandidatePair = activeIceCandidatePairStatsReport;
     return statsResponse;
@@ -64,13 +64,18 @@ function _getStats(peerConnection, options) {
  * Generate the {@link StandardizedActiveIceCandidatePairStatsReport} for the
  * {@link RTCPeerConnection}.
  * @param {RTCPeerConnection} peerConnection
+ * @param {object} [options]
  * @returns {Promise<StandardizedActiveIceCandidatePairStatsReport>}
  */
-function getActiveIceCandidatePairStats(peerConnection) {
-  if (typeof webkitRTCPeerConnection !== 'undefined') {
+function getActiveIceCandidatePairStats(peerConnection, options) {
+  options = options || {};
+
+  if (typeof options.testForChrome !== 'undefined'
+    || typeof webkitRTCPeerConnection !== 'undefined') {
     return peerConnection.getStats().then(standardizeChromeActiveIceCandidatePairStats);
   }
-  if (typeof mozRTCPeerConnection !== 'undefined') {
+  if (typeof options.testForFirefox !== 'undefined'
+    || typeof mozRTCPeerConnection !== 'undefined') {
     return peerConnection.getStats().then(standardizeFirefoxActiveIceCandidatePairStats);
   }
   return Promise.reject(new Error('RTCPeerConnection#getStats() not supported'));
@@ -82,8 +87,7 @@ function getActiveIceCandidatePairStats(peerConnection) {
  * @returns {?StandardizedActiveIceCandidatePairStatsReport}
  */
 function standardizeChromeActiveIceCandidatePairStats(stats) {
-  stats = Array.from(stats.values());
-  var activeCandidatePairStats = stats.find(function(stat) {
+  var activeCandidatePairStats = Array.from(stats.values()).find(function(stat) {
     return stat.type === 'candidate-pair' && stat.nominated;
   });
 
@@ -91,13 +95,8 @@ function standardizeChromeActiveIceCandidatePairStats(stats) {
     return null;
   }
 
-  var activeLocalCandidateStats = stats.find(function(stat) {
-    return stat.id === activeCandidatePairStats.localCandidateId;
-  });
-
-  var activeRemoteCandidateStats = stats.find(function(stat) {
-    return stat.id === activeCandidatePairStats.remoteCandidateId;
-  });
+  var activeLocalCandidateStats = stats.get(activeCandidatePairStats.localCandidateId);
+  var activeRemoteCandidateStats = stats.get(activeCandidatePairStats.remoteCandidateId);
 
   var standardizedCandidateStatsKeys = [
     { key: 'candidateType', type: 'string' },
@@ -170,8 +169,7 @@ function standardizeChromeActiveIceCandidatePairStats(stats) {
  * @returns {?StandardizedActiveIceCandidatePairStatsReport}
  */
 function standardizeFirefoxActiveIceCandidatePairStats(stats) {
-  stats = Object.values(stats);
-  var activeCandidatePairStats = stats.find(function(stat) {
+  var activeCandidatePairStats = Object.values(stats).find(function(stat) {
     return stat.type === 'candidatepair' && stat.nominated;
   });
 
@@ -179,13 +177,8 @@ function standardizeFirefoxActiveIceCandidatePairStats(stats) {
     return null;
   }
 
-  var activeLocalCandidateStats = stats.find(function(stat) {
-    return stat.id === activeCandidatePairStats.localCandidateId;
-  });
-
-  var activeRemoteCandidateStats = stats.find(function(stat) {
-    return stat.id === activeCandidatePairStats.remoteCandidateId;
-  });
+  var activeLocalCandidateStats = stats[activeCandidatePairStats.localCandidateId];
+  var activeRemoteCandidateStats = stats[activeCandidatePairStats.remoteCandidateId];
 
   var standardizedCandidateStatsKeys = [
     { key: 'candidateType', type: 'string' },
@@ -205,7 +198,14 @@ function standardizeFirefoxActiveIceCandidatePairStats(stats) {
     ? standardizedLocalCandidateStatsKeys.reduce(function(report, keyInfo) {
       var key = keyInfo.ffKey || keyInfo.key;
       report[keyInfo.key] = typeof activeLocalCandidateStats[key] === keyInfo.type
-        ? activeLocalCandidateStats[key]
+        ? key === 'candidateType'
+          ? {
+            host: 'host',
+            peerreflexive: 'prflx',
+            relayed: 'relay',
+            serverreflexive: 'srflx'
+          }[activeLocalCandidateStats[key]]
+          : activeLocalCandidateStats[key]
         : key === 'deleted' ? false : null;
       return report;
     }, {})

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -29,6 +29,7 @@ function _getStats(peerConnection, options) {
   var remoteVideoTracks = getTracks(peerConnection, 'video');
 
   var statsResponse = {
+    activeIceCandidatePair: null,
     localAudioTrackStats: [],
     localVideoTrackStats: [],
     remoteAudioTrackStats: [],
@@ -52,7 +53,113 @@ function _getStats(peerConnection, options) {
   });
 
   return Promise.all(trackStatsPromises).then(function() {
+    return getActiveIceCandidatePairStats(peerConnection);
+  }).then(function(activeIceCandidatePairStatsReport) {
+    statsResponse.activeIceCandidatePair = activeIceCandidatePairStatsReport;
     return statsResponse;
+  });
+}
+
+/**
+ * Generate the {@link StandardizedActiveIceCandidatePairStatsReport} for the
+ * {@link RTCPeerConnection}.
+ * @param {RTCPeerConnection} peerConnection
+ * @returns {Promise<?StandardizedActiveIceCandidatePairStatsReport>}
+ */
+function getActiveIceCandidatePairStats(peerConnection) {
+  if (typeof webkitRTCPeerConnection === 'undefined') {
+    return Promise.resolve(null);
+  }
+  return peerConnection.getStats().then(function(stats) {
+    return standardizeChromeActiveIceCandidatePairStats(stats);
+  });
+}
+
+/**
+ * Standardize the active RTCIceCandidate pair's statistics in Chrome.
+ * @param {RTCStatsReport} stats
+ * @returns {?StandardizedActiveIceCandidatePairStatsReport}
+ */
+function standardizeChromeActiveIceCandidatePairStats(stats) {
+  stats = Array.from(stats.values());
+  var activeCandidatePairStats = stats.find(function(stat) {
+    return stat.type === 'candidate-pair' && stat.nominated;
+  });
+
+  if (!activeCandidatePairStats) {
+    return null;
+  }
+
+  var activeLocalCandidateStats = stats.find(function(stat) {
+    return stat.id === activeCandidatePairStats.localCandidateId;
+  });
+
+  var activeRemoteCandidateStats = stats.find(function(stat) {
+    return stat.id === activeCandidatePairStats.remoteCandidateId;
+  });
+
+  var standardizedCandidateStatsKeys = [
+    { key: 'candidateType', type: 'string' },
+    { key: 'ip', type: 'string' },
+    { key: 'port', type: 'number' },
+    { key: 'priority', type: 'number' },
+    { key: 'protocol', type: 'string' },
+    { key: 'url', type: 'string' }
+  ];
+
+  var standardizedLocalCandidateStatsKeys = standardizedCandidateStatsKeys.concat([
+    { key: 'deleted', type: 'boolean' },
+    { key: 'relayProtocol', type: 'string' }
+  ]);
+
+  var standatdizedLocalCandidateStatsReport = activeLocalCandidateStats
+    ? standardizedLocalCandidateStatsKeys.reduce(function(report, keyInfo) {
+      report[keyInfo.key] = typeof activeLocalCandidateStats[keyInfo.key] === keyInfo.type
+        ? activeLocalCandidateStats[keyInfo.key]
+        : keyInfo.key === 'deleted' ? false : null;
+      return report;
+    }, {})
+    : null;
+
+  var standardizedRemoteCandidateStatsReport = activeRemoteCandidateStats
+    ? standardizedCandidateStatsKeys.reduce(function(report, keyInfo) {
+      report[keyInfo.key] = typeof activeRemoteCandidateStats[keyInfo.key] === keyInfo.type
+        ? activeRemoteCandidateStats[keyInfo.key]
+        : null;
+      return report;
+    }, {})
+    : null;
+
+  return [
+    { key: 'availableIncomingBitrate', type: 'number' },
+    { key: 'availableOutgoingBitrate', type: 'number' },
+    { key: 'bytesReceived', type: 'number' },
+    { key: 'bytesSent', type: 'number' },
+    { key: 'consentRequestsSent', type: 'number' },
+    { key: 'currentRoundTripTime', type: 'number' },
+    { key: 'lastPacketReceivedTimestamp', type: 'number' },
+    { key: 'lastPacketSentTimestamp', type: 'number' },
+    { key: 'nominated', type: 'boolean' },
+    { key: 'priority', type: 'number' },
+    { key: 'readable', type: 'boolean' },
+    { key: 'requestsReceived', type: 'number' },
+    { key: 'requestsSent', type: 'number' },
+    { key: 'responsesReceived', type: 'number' },
+    { key: 'responsesSent', type: 'number' },
+    { key: 'retransmissionsReceived', type: 'number' },
+    { key: 'retransmissionsSent', type: 'number' },
+    { key: 'state', type: 'string' },
+    { key: 'totalRoundTripTime', type: 'number' },
+    { key: 'transportId', type: 'string' },
+    { key: 'writable', type: 'boolean' }
+  ].reduce(function(report, keyInfo) {
+    report[keyInfo.key] = typeof activeCandidatePairStats[keyInfo.key] === keyInfo.type
+      ? activeCandidatePairStats[keyInfo.key]
+      : null;
+    return report;
+  }, {
+    localCandidate: standatdizedLocalCandidateStatsReport,
+    remoteCandidate: standardizedRemoteCandidateStatsReport
   });
 }
 
@@ -302,9 +409,57 @@ function standardizeFirefoxStats(response) {
   return standardizedStats;
 }
 
+
+/**
+ * Standardized RTCIceCandidate statistics.
+ * @typedef {object} StandardizedIceCandidateStatsReport
+ * @property {'host'|'prflx'|'relay'|'srflx'} candidateType
+ * @property {string} ip
+ * @property {number} port
+ * @property {number} priority
+ * @property {'tcp'|'udp'} protocol
+ * @property {string} url
+ */
+
+/**
+ * Standardized local RTCIceCandidate statistics.
+ * @typedef {StandardizedIceCandidateStatsReport} StandardizedLocalIceCandidateStatsReport
+ * @property {boolean} [deleted=false]
+ * @property {'tcp'|'tls'|'udp'} relayProtocol
+ */
+
+/**
+ * Standardized active RTCIceCandidate pair statistics.
+ * @typedef {object} StandardizedActiveIceCandidatePairStatsReport
+ * @property {number} availableIncomingBitrate
+ * @property {number} availableOutgoingBitrate
+ * @property {number} bytesReceived
+ * @property {number} bytesSent
+ * @property {number} consentRequestsSent
+ * @property {number} currentRoundTripTime
+ * @property {number} lastPacketReceivedTimestamp
+ * @property {number} lastPacketSentTimestamp
+ * @property {StandardizedLocalIceCandidateStatsReport} localCandidate
+ * @property {boolean} nominated
+ * @property {number} priority
+ * @property {boolean} readable
+ * @property {StandardizedIceCandidateStatsReport} remoteCandidate
+ * @property {number} requestsReceived
+ * @property {number} requestsSent
+ * @property {number} responsesReceived
+ * @property {number} responsesSent
+ * @property {number} retransmissionsReceived
+ * @property {number} retransmissionsSent
+ * @property {'frozen'|'waiting'|'in-progress'|'failed'|'succeeded'} state
+ * @property {number} totalRoundTripTime
+ * @property {string} transportId
+ * @property {boolean} writable
+ */
+
 /**
  * Standardized {@link RTCPeerConnection} statistics.
  * @typedef {Object} StandardizedStatsResponse
+ * @property {?StandardizedActiveIceCandidatePairStatsReport} activeIceCandidatePair - Stats for active ICE candidate pair
  * @property Array<StandardizedTrackStatsReport> localAudioTracks - Stats for local audio MediaStreamTracks
  * @property Array<StandardizedTrackStatsReport> localVideoTracks - Stats for local video MediaStreamTracks
  * @property Array<StandardizedTrackStatsReport> remoteAudioTracks - Stats for remote audio MediaStreamTracks

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -194,17 +194,19 @@ function standardizeFirefoxActiveIceCandidatePairStats(stats) {
     { key: 'relayProtocol', type: 'string' }
   ]);
 
+  var candidateTypes = {
+    host: 'host',
+    peerreflexive: 'prflx',
+    relayed: 'relay',
+    serverreflexive: 'srflx'
+  };
+
   var standatdizedLocalCandidateStatsReport = activeLocalCandidateStats
     ? standardizedLocalCandidateStatsKeys.reduce(function(report, keyInfo) {
       var key = keyInfo.ffKey || keyInfo.key;
       report[keyInfo.key] = typeof activeLocalCandidateStats[key] === keyInfo.type
         ? key === 'candidateType'
-          ? {
-            host: 'host',
-            peerreflexive: 'prflx',
-            relayed: 'relay',
-            serverreflexive: 'srflx'
-          }[activeLocalCandidateStats[key]]
+          ? candidateTypes[activeLocalCandidateStats[key]]
           : activeLocalCandidateStats[key]
         : key === 'deleted' ? false : null;
       return report;
@@ -215,7 +217,9 @@ function standardizeFirefoxActiveIceCandidatePairStats(stats) {
     ? standardizedCandidateStatsKeys.reduce(function(report, keyInfo) {
       var key = keyInfo.ffKey || keyInfo.key;
       report[keyInfo.key] = typeof activeRemoteCandidateStats[key] === keyInfo.type
-        ? activeRemoteCandidateStats[key]
+        ? key === 'candidateType'
+          ? candidateTypes[activeRemoteCandidateStats[key]]
+          : activeRemoteCandidateStats[key]
         : null;
       return report;
     }, {})

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -64,15 +64,16 @@ function _getStats(peerConnection, options) {
  * Generate the {@link StandardizedActiveIceCandidatePairStatsReport} for the
  * {@link RTCPeerConnection}.
  * @param {RTCPeerConnection} peerConnection
- * @returns {Promise<?StandardizedActiveIceCandidatePairStatsReport>}
+ * @returns {Promise<StandardizedActiveIceCandidatePairStatsReport>}
  */
 function getActiveIceCandidatePairStats(peerConnection) {
-  if (typeof webkitRTCPeerConnection === 'undefined') {
-    return Promise.resolve(null);
+  if (typeof webkitRTCPeerConnection !== 'undefined') {
+    return peerConnection.getStats().then(standardizeChromeActiveIceCandidatePairStats);
   }
-  return peerConnection.getStats().then(function(stats) {
-    return standardizeChromeActiveIceCandidatePairStats(stats);
-  });
+  if (typeof mozRTCPeerConnection !== 'undefined') {
+    return peerConnection.getStats().then(standardizeFirefoxActiveIceCandidatePairStats);
+  }
+  return Promise.reject(new Error('RTCPeerConnection#getStats() not supported'));
 }
 
 /**
@@ -125,6 +126,96 @@ function standardizeChromeActiveIceCandidatePairStats(stats) {
     ? standardizedCandidateStatsKeys.reduce(function(report, keyInfo) {
       report[keyInfo.key] = typeof activeRemoteCandidateStats[keyInfo.key] === keyInfo.type
         ? activeRemoteCandidateStats[keyInfo.key]
+        : null;
+      return report;
+    }, {})
+    : null;
+
+  return [
+    { key: 'availableIncomingBitrate', type: 'number' },
+    { key: 'availableOutgoingBitrate', type: 'number' },
+    { key: 'bytesReceived', type: 'number' },
+    { key: 'bytesSent', type: 'number' },
+    { key: 'consentRequestsSent', type: 'number' },
+    { key: 'currentRoundTripTime', type: 'number' },
+    { key: 'lastPacketReceivedTimestamp', type: 'number' },
+    { key: 'lastPacketSentTimestamp', type: 'number' },
+    { key: 'nominated', type: 'boolean' },
+    { key: 'priority', type: 'number' },
+    { key: 'readable', type: 'boolean' },
+    { key: 'requestsReceived', type: 'number' },
+    { key: 'requestsSent', type: 'number' },
+    { key: 'responsesReceived', type: 'number' },
+    { key: 'responsesSent', type: 'number' },
+    { key: 'retransmissionsReceived', type: 'number' },
+    { key: 'retransmissionsSent', type: 'number' },
+    { key: 'state', type: 'string' },
+    { key: 'totalRoundTripTime', type: 'number' },
+    { key: 'transportId', type: 'string' },
+    { key: 'writable', type: 'boolean' }
+  ].reduce(function(report, keyInfo) {
+    report[keyInfo.key] = typeof activeCandidatePairStats[keyInfo.key] === keyInfo.type
+      ? activeCandidatePairStats[keyInfo.key]
+      : null;
+    return report;
+  }, {
+    localCandidate: standatdizedLocalCandidateStatsReport,
+    remoteCandidate: standardizedRemoteCandidateStatsReport
+  });
+}
+
+/**
+ * Standardize the active RTCIceCandidate pair's statistics in Firefox.
+ * @param {RTCStatsReport} stats
+ * @returns {?StandardizedActiveIceCandidatePairStatsReport}
+ */
+function standardizeFirefoxActiveIceCandidatePairStats(stats) {
+  stats = Object.values(stats);
+  var activeCandidatePairStats = stats.find(function(stat) {
+    return stat.type === 'candidatepair' && stat.nominated;
+  });
+
+  if (!activeCandidatePairStats) {
+    return null;
+  }
+
+  var activeLocalCandidateStats = stats.find(function(stat) {
+    return stat.id === activeCandidatePairStats.localCandidateId;
+  });
+
+  var activeRemoteCandidateStats = stats.find(function(stat) {
+    return stat.id === activeCandidatePairStats.remoteCandidateId;
+  });
+
+  var standardizedCandidateStatsKeys = [
+    { key: 'candidateType', type: 'string' },
+    { key: 'ip', ffKey: 'ipAddress', type: 'string' },
+    { key: 'port', ffKey: 'portNumber', type: 'number' },
+    { key: 'priority', type: 'number' },
+    { key: 'protocol', ffKey: 'transport', type: 'string' },
+    { key: 'url', type: 'string' }
+  ];
+
+  var standardizedLocalCandidateStatsKeys = standardizedCandidateStatsKeys.concat([
+    { key: 'deleted', type: 'boolean' },
+    { key: 'relayProtocol', type: 'string' }
+  ]);
+
+  var standatdizedLocalCandidateStatsReport = activeLocalCandidateStats
+    ? standardizedLocalCandidateStatsKeys.reduce(function(report, keyInfo) {
+      var key = keyInfo.ffKey || keyInfo.key;
+      report[keyInfo.key] = typeof activeLocalCandidateStats[key] === keyInfo.type
+        ? activeLocalCandidateStats[key]
+        : key === 'deleted' ? false : null;
+      return report;
+    }, {})
+    : null;
+
+  var standardizedRemoteCandidateStatsReport = activeRemoteCandidateStats
+    ? standardizedCandidateStatsKeys.reduce(function(report, keyInfo) {
+      var key = keyInfo.ffKey || keyInfo.key;
+      report[keyInfo.key] = typeof activeRemoteCandidateStats[key] === keyInfo.type
+        ? activeRemoteCandidateStats[key]
         : null;
       return report;
     }, {})
@@ -459,7 +550,7 @@ function standardizeFirefoxStats(response) {
 /**
  * Standardized {@link RTCPeerConnection} statistics.
  * @typedef {Object} StandardizedStatsResponse
- * @property {?StandardizedActiveIceCandidatePairStatsReport} activeIceCandidatePair - Stats for active ICE candidate pair
+ * @property {StandardizedActiveIceCandidatePairStatsReport} activeIceCandidatePair - Stats for active ICE candidate pair
  * @property Array<StandardizedTrackStatsReport> localAudioTracks - Stats for local audio MediaStreamTracks
  * @property Array<StandardizedTrackStatsReport> localVideoTracks - Stats for local video MediaStreamTracks
  * @property Array<StandardizedTrackStatsReport> remoteAudioTracks - Stats for remote audio MediaStreamTracks

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -206,7 +206,7 @@ function standardizeFirefoxActiveIceCandidatePairStats(stats) {
       var key = keyInfo.ffKey || keyInfo.key;
       report[keyInfo.key] = typeof activeLocalCandidateStats[key] === keyInfo.type
         ? key === 'candidateType'
-          ? candidateTypes[activeLocalCandidateStats[key]]
+          ? candidateTypes[activeLocalCandidateStats[key]] || activeLocalCandidateStats[key]
           : activeLocalCandidateStats[key]
         : key === 'deleted' ? false : null;
       return report;
@@ -218,7 +218,7 @@ function standardizeFirefoxActiveIceCandidatePairStats(stats) {
       var key = keyInfo.ffKey || keyInfo.key;
       report[keyInfo.key] = typeof activeRemoteCandidateStats[key] === keyInfo.type
         ? key === 'candidateType'
-          ? candidateTypes[activeRemoteCandidateStats[key]]
+          ? candidateTypes[activeRemoteCandidateStats[key]] || activeRemoteCandidateStats[key]
           : activeRemoteCandidateStats[key]
         : null;
       return report;

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -6,5 +6,6 @@ if (typeof adapter !== 'undefined') {
   console.log(adapter);
 }
 
+require('./spec/getstats');
 require('./spec/rtcpeerconnection');
 require('./spec/rtcsessiondescription');

--- a/test/integration/spec/getstats.js
+++ b/test/integration/spec/getstats.js
@@ -1,4 +1,11 @@
 const assert = require('assert');
+
+const {
+  activeIceCandidatePairStatsNullProps,
+  localCandidateStatsNullProps,
+  remoteCandidateStatsNullProps
+} = require('../../lib/util');
+
 const getStats = require('../../../lib/getstats');
 const getUserMedia = require('../../../lib/getusermedia');
 const RTCPeerConnection = require('../../../lib/rtcpeerconnection');
@@ -47,7 +54,7 @@ const { guessBrowser } = require('../../../lib/util');
         pc2.addIceCandidate(e.candidate);
       });
 
-      pc1.addEventListener('icecandidate', e => {
+      pc2.addEventListener('icecandidate', e => {
         if (e.candidate) {
           pc1.addIceCandidate(e.candidate);
         }
@@ -76,8 +83,9 @@ const { guessBrowser } = require('../../../lib/util');
         { key: 'protocol', type: 'string' },
         { key: 'url', type: 'string' }
       ].forEach(({ key, type }) => {
-        [localCandidate, remoteCandidate].forEach(candidate => {
-          if (candidate[key] === null) {
+        [localCandidate, remoteCandidate].forEach((candidate, i) => {
+          if ([localCandidateStatsNullProps, remoteCandidateStatsNullProps][i][guessBrowser()].has(key)) {
+            assert.equal(candidate[key], null);
             return;
           }
           if (key === 'candidateType') {
@@ -106,7 +114,8 @@ const { guessBrowser } = require('../../../lib/util');
         { key: 'deleted', type: 'boolean' },
         { key: 'relayProtocol', type: 'string' }
       ].forEach(({ key, type }) => {
-        if (localCandidate[key] === null) {
+        if (localCandidateStatsNullProps[guessBrowser()].has(key)) {
+          assert.equal(localCandidate[key], null);
           return;
         }
         if (key === 'relayProtocol') {
@@ -143,7 +152,8 @@ const { guessBrowser } = require('../../../lib/util');
         { key: 'transportId', type: 'string' },
         { key: 'writable', type: 'boolean' }
       ].forEach(({ key, type }) => {
-        if (activeIceCandidatePair[key] === null) {
+        if (activeIceCandidatePairStatsNullProps[guessBrowser()].has(key)) {
+          assert.equal(activeIceCandidatePair[key], null);
           return;
         }
         if (key === 'state') {

--- a/test/integration/spec/getstats.js
+++ b/test/integration/spec/getstats.js
@@ -1,0 +1,169 @@
+const assert = require('assert');
+const getStats = require('../../../lib/getstats');
+const getUserMedia = require('../../../lib/getusermedia');
+const RTCPeerConnection = require('../../../lib/rtcpeerconnection');
+const { guessBrowser } = require('../../../lib/util');
+
+(guessBrowser() === 'safari' ? describe.skip : describe)('getStats', () => {
+  describe('should resolve a Promise that resolves with a StandardizedStatsResponse which has', () => {
+    let pc1;
+    let pc2;
+    let stats;
+    let stream;
+
+    before(async () => {
+      stream = await getUserMedia({
+        audio: true,
+        fake: true,
+        video: true
+      });
+
+      pc1 = new RTCPeerConnection({
+        iceServers: [{
+          urls: 'stun:stun.l.google.com:19302'
+        }]
+      });
+
+      pc2 = new RTCPeerConnection({
+        iceServers: [{
+          urls: 'stun:stun.l.google.com:19302'
+        }]
+      });
+
+      stream.getTracks().forEach(track => pc1.addTrack(track, stream));
+      stream.getTracks().forEach(track => pc2.addTrack(track, stream));
+
+      const deferred = {};
+      deferred.promise = new Promise((resolve, reject) => {
+        deferred.resolve = resolve;
+        deferred.reject = reject;
+      });
+
+      pc1.addEventListener('icecandidate', e => {
+        if (!e.candidate) {
+          deferred.resolve();
+          return;
+        }
+        pc2.addIceCandidate(e.candidate);
+      });
+
+      pc1.addEventListener('icecandidate', e => {
+        if (e.candidate) {
+          pc1.addIceCandidate(e.candidate);
+        }
+      });
+
+      const offer = await pc1.createOffer();
+      await pc1.setLocalDescription(offer);
+      await pc2.setRemoteDescription(offer);
+
+      const answer = await pc2.createAnswer();
+      await pc2.setLocalDescription(answer);
+      await pc1.setRemoteDescription(answer);
+      await deferred.promise;
+      stats = await getStats(pc1);
+    });
+
+    it('.activeIceCandidatePair', () => {
+      const { activeIceCandidatePair } = stats;
+      const { localCandidate, remoteCandidate } = activeIceCandidatePair;
+
+      [
+        { key: 'candidateType', type: 'string' },
+        { key: 'ip', type: 'string' },
+        { key: 'port', type: 'number' },
+        { key: 'priority', type: 'number' },
+        { key: 'protocol', type: 'string' },
+        { key: 'url', type: 'string' }
+      ].forEach(({ key, type }) => {
+        [localCandidate, remoteCandidate].forEach(candidate => {
+          if (candidate[key] === null) {
+            return;
+          }
+          if (key === 'candidateType') {
+            const candidateTypes = new Set([
+              'host',
+              'prflx',
+              'relay',
+              'srflx'
+            ]);
+            assert(candidateTypes.has(candidate[key]));
+            return;
+          }
+          if (key === 'protocol') {
+            const protocols = new Set([
+              'tcp',
+              'udp'
+            ]);
+            assert(protocols.has(candidate[key]));
+            return;
+          }
+          assert.equal(typeof candidate[key], type);
+        });
+      });
+
+      [
+        { key: 'deleted', type: 'boolean' },
+        { key: 'relayProtocol', type: 'string' }
+      ].forEach(({ key, type }) => {
+        if (localCandidate[key] === null) {
+          return;
+        }
+        if (key === 'relayProtocol') {
+          assert(new Set([
+            'tcp',
+            'tls',
+            'udp'
+          ]).has(localCandidate[key]));
+          return;
+        }
+        assert.equal(typeof localCandidate[key], type);
+      });
+
+      [
+        { key: 'availableIncomingBitrate', type: 'number' },
+        { key: 'availableOutgoingBitrate', type: 'number' },
+        { key: 'bytesReceived', type: 'number' },
+        { key: 'bytesSent', type: 'number' },
+        { key: 'consentRequestsSent', type: 'number' },
+        { key: 'currentRoundTripTime', type: 'number' },
+        { key: 'lastPacketReceivedTimestamp', type: 'number' },
+        { key: 'lastPacketSentTimestamp', type: 'number' },
+        { key: 'nominated', type: 'boolean' },
+        { key: 'priority', type: 'number' },
+        { key: 'readable', type: 'boolean' },
+        { key: 'requestsReceived', type: 'number' },
+        { key: 'requestsSent', type: 'number' },
+        { key: 'responsesReceived', type: 'number' },
+        { key: 'responsesSent', type: 'number' },
+        { key: 'retransmissionsReceived', type: 'number' },
+        { key: 'retransmissionsSent', type: 'number' },
+        { key: 'state', type: 'string' },
+        { key: 'totalRoundTripTime', type: 'number' },
+        { key: 'transportId', type: 'string' },
+        { key: 'writable', type: 'boolean' }
+      ].forEach(({ key, type }) => {
+        if (activeIceCandidatePair[key] === null) {
+          return;
+        }
+        if (key === 'state') {
+          assert(new Set([
+            'failed',
+            'frozen',
+            'in-progress',
+            'succeeded',
+            'waiting'
+          ]).has(activeIceCandidatePair[key]));
+          return;
+        }
+        assert.equal(typeof activeIceCandidatePair[key], type);
+      });
+    });
+
+    after(() => {
+      stream.getTracks().forEach(track => track.stop());
+      pc1.close();
+      pc2.close();
+    });
+  });
+});

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -240,6 +240,44 @@ async function trackStarted(track) {
   await new Promise(resolve => track.once('started', resolve));
 }
 
+const activeIceCandidatePairStatsNullProps = {
+  chrome: new Set([
+    'availableIncomingBitrate',
+    'lastPacketReceivedTimestamp',
+    'lastPacketSentTimestamp',
+    'readable',
+    'retransmissionsReceived',
+    'retransmissionsSent'
+  ]),
+  firefox: new Set([
+    'availableIncomingBitrate',
+    'availableOutgoingBitrate',
+    'consentRequestsSent',
+    'currentRoundTripTime',
+    'requestsReceived',
+    'requestsSent',
+    'responsesReceived',
+    'responsesSent',
+    'retransmissionsReceived',
+    'retransmissionsSent',
+    'totalRoundTripTime'
+  ])
+};
+
+const localCandidateStatsNullProps = {
+  chrome: new Set(['relayProtocol', 'url']),
+  firefox: new Set(['priority', 'relayProtocol', 'url'])
+};
+
+const remoteCandidateStatsNullProps = {
+  chrome: new Set(['url']),
+  firefox: new Set(['priority', 'url'])
+};
+
+exports.activeIceCandidatePairStatsNullProps = activeIceCandidatePairStatsNullProps;
+exports.localCandidateStatsNullProps = localCandidateStatsNullProps;
+exports.remoteCandidateStatsNullProps = remoteCandidateStatsNullProps;
+
 exports.a = a;
 exports.capitalize = capitalize;
 exports.combinationContext = combinationContext;

--- a/test/unit/spec/getstats.js
+++ b/test/unit/spec/getstats.js
@@ -89,7 +89,8 @@ describe('getStats', function() {
         packetsSent: 900,
         audioInputLevel: 80,
         audioOutputLevel: 65
-      }
+      },
+      chromeFakeIceStats: []
     };
     var peerConnection = new FakeRTCPeerConnection(options);
     var localStream = new FakeMediaStream();
@@ -263,5 +264,547 @@ describe('getStats', function() {
             assert.equal(report.packetsSent, fakeOutbound.packetsSent);
           });
       });
+  });
+
+  describe('Active RTCIceCandidate pair stats', () => {
+    context('should be present in StandardizedStatsResponse for', () => {
+      it('chrome', async () => {
+        var options = {
+          chromeFakeStats: {},
+          chromeFakeIceStats: [
+            {
+              id: 'RTCIceCandidatePair_F/5cS67H_6FQI1GQj',
+              timestamp: 1525111897754.9,
+              type: 'candidate-pair',
+              transportId: 'RTCTransport_audio_1',
+              localCandidateId: 'RTCIceCandidate_F/5cS67H',
+              remoteCandidateId: 'RTCIceCandidate_6FQI1GQj',
+              state: 'succeeded',
+              priority: 1.7961621859063e+17,
+              nominated: false,
+              writable: true,
+              bytesSent: 0,
+              bytesReceived: 0,
+              totalRoundTripTime: 3.328,
+              currentRoundTripTime: 0.134,
+              requestsReceived: 0,
+              requestsSent: 1,
+              responsesReceived: 14,
+              responsesSent: 0,
+              consentRequestsSent: 13
+            },
+            {
+              id: 'RTCIceCandidatePair_iAkACmH6_U+HD8VMp',
+              timestamp: 1525111897754.9,
+              type: 'candidate-pair',
+              transportId: 'RTCTransport_audio_1',
+              localCandidateId: 'RTCIceCandidate_iAkACmH6',
+              remoteCandidateId: 'RTCIceCandidate_U+HD8VMp',
+              state: 'waiting',
+              priority: 1.7961621859063e+17,
+              nominated: false,
+              writable: false,
+              bytesSent: 0,
+              bytesReceived: 0,
+              totalRoundTripTime: 0,
+              requestsReceived: 14,
+              requestsSent: 0,
+              responsesReceived: 0,
+              responsesSent: 14,
+              consentRequestsSent: 0
+            },
+            {
+              id: 'RTCIceCandidatePair_rO9TbAZ1_wSP+1iQn',
+              timestamp: 1525111897754.9,
+              type: 'candidate-pair',
+              transportId: 'RTCTransport_audio_1',
+              localCandidateId: 'RTCIceCandidate_rO9TbAZ1',
+              remoteCandidateId: 'RTCIceCandidate_wSP+1iQn',
+              state: 'succeeded',
+              priority: 9.1147567806543e+18,
+              nominated: true,
+              writable: true,
+              bytesSent: 760278,
+              bytesReceived: 754186,
+              totalRoundTripTime: 0.049,
+              currentRoundTripTime: 0.001,
+              availableOutgoingBitrate: 300000,
+              requestsReceived: 65,
+              requestsSent: 1,
+              responsesReceived: 65,
+              responsesSent: 65,
+              consentRequestsSent: 64
+            },
+            {
+              id: 'RTCIceCandidate_6FQI1GQj',
+              timestamp: 1525111897754.9,
+              type: 'remote-candidate',
+              transportId: 'RTCTransport_audio_1',
+              isRemote: true,
+              ip: '34.203.250.85',
+              port: 51850,
+              protocol: 'udp',
+              candidateType: 'relay',
+              priority: 41820159,
+              deleted: false
+            },
+            {
+              id: 'RTCIceCandidate_F/5cS67H',
+              timestamp: 1525111897754.9,
+              type: 'local-candidate',
+              transportId: 'RTCTransport_audio_1',
+              isRemote: false,
+              networkType: 'unknown',
+              ip: '107.20.226.156',
+              port: 57710,
+              protocol: 'udp',
+              candidateType: 'srflx',
+              priority: 1686052607,
+              deleted: false
+            },
+            {
+              id: 'RTCIceCandidate_U+HD8VMp',
+              timestamp: 1525111897754.9,
+              type: 'remote-candidate',
+              transportId: 'RTCTransport_audio_1',
+              isRemote: true,
+              ip: '107.20.226.156',
+              port: 59522,
+              protocol: 'udp',
+              candidateType: 'srflx',
+              priority: 1686052607,
+              deleted: false
+            },
+            {
+              id: 'RTCIceCandidate_iAkACmH6',
+              timestamp: 1525111897754.9,
+              type: 'local-candidate',
+              transportId: 'RTCTransport_audio_1',
+              isRemote: false,
+              networkType: 'wifi',
+              ip: '34.203.250.85',
+              port: 53529,
+              protocol: 'udp',
+              candidateType: 'relay',
+              priority: 41820159,
+              deleted: false
+            },
+            {
+              id: 'RTCIceCandidate_rO9TbAZ1',
+              timestamp: 1525111897754.9,
+              type: 'local-candidate',
+              transportId: 'RTCTransport_audio_1',
+              isRemote: false,
+              networkType: 'wifi',
+              ip: '10.20.64.226',
+              port: 61772,
+              protocol: 'udp',
+              candidateType: 'host',
+              priority: 2122194687,
+              deleted: false
+            },
+            {
+              id: 'RTCIceCandidate_wSP+1iQn',
+              timestamp: 1525111897754.9,
+              type: 'remote-candidate',
+              transportId: 'RTCTransport_audio_1',
+              isRemote: true,
+              ip: '10.20.64.226',
+              port: 61913,
+              protocol: 'udp',
+              candidateType: 'host',
+              priority: 2122194687,
+              deleted: false
+            }
+          ]
+        };
+        var peerConnection = new FakeRTCPeerConnection(options);
+        var { activeIceCandidatePair } = await getStats(peerConnection, { testForChrome: true });
+
+        var expectedActiveIceCandidatePair = options.chromeFakeIceStats.find(stat => {
+          return stat.nominated;
+        });
+        var expectedActiveLocalCandidate = options.chromeFakeIceStats.find(stat => {
+          return stat.id === expectedActiveIceCandidatePair.localCandidateId;
+        });
+        var expectedActiveRemoteCandidate = options.chromeFakeIceStats.find(stat => {
+          return stat.id === expectedActiveIceCandidatePair.remoteCandidateId;
+        });
+
+        [
+          'availableIncomingBitrate',
+          'availableOutgoingBitrate',
+          'bytesReceived',
+          'bytesSent',
+          'consentRequestsSent',
+          'currentRoundTripTime',
+          'lastPacketReceivedTimestamp',
+          'lastPacketSentTimestamp',
+          'nominated',
+          'priority',
+          'readable',
+          'requestsReceived',
+          'requestsSent',
+          'responsesReceived',
+          'responsesSent',
+          'retransmissionsReceived',
+          'retransmissionsSent',
+          'state',
+          'totalRoundTripTime',
+          'transportId',
+          'writable'
+        ].forEach(key => {
+          assert.equal(activeIceCandidatePair[key], typeof expectedActiveIceCandidatePair[key] !== 'undefined'
+            ? expectedActiveIceCandidatePair[key]
+            :null);
+        });
+
+        [
+          'candidateType',
+          'deleted',
+          'ip',
+          'port',
+          'priority',
+          'protocol',
+          'relayProtocol',
+          'url'
+        ].forEach(key => {
+          assert.equal(activeIceCandidatePair.localCandidate[key], typeof expectedActiveLocalCandidate[key] !== 'undefined'
+            ? expectedActiveLocalCandidate[key]
+            : null);
+        });
+
+        [
+          'candidateType',
+          'ip',
+          'port',
+          'priority',
+          'protocol',
+          'url'
+        ].forEach(key => {
+          assert.equal(activeIceCandidatePair.remoteCandidate[key], typeof expectedActiveRemoteCandidate[key] !== 'undefined'
+            ? expectedActiveRemoteCandidate[key]
+            : null);
+        });
+      });
+
+      it('firefox', async () => {
+        var options = {
+          firefoxFakeStats: {
+            'Gmx9': {
+              id: 'Gmx9',
+              timestamp: 1525115247978,
+              type: 'candidatepair',
+              bytesReceived: 591211,
+              bytesSent: 591293,
+              lastPacketReceivedTimestamp: 1525115247973,
+              lastPacketSentTimestamp: 1525115247974,
+              localCandidateId: 'kvar',
+              nominated: true,
+              priority: 9.1150052702823e+18,
+              readable: true,
+              remoteCandidateId: 'xLZB',
+              selected: true,
+              state: 'succeeded',
+              transportId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              writable: true
+            },
+            '9NHy': {
+              id: '9NHy',
+              timestamp: 1525115247978,
+              type: 'candidatepair',
+              bytesReceived: 0,
+              bytesSent: 0,
+              lastPacketReceivedTimestamp: 0,
+              lastPacketSentTimestamp: 0,
+              localCandidateId: 'eN95',
+              nominated: false,
+              priority: 9.1147237953056e+18,
+              readable: true,
+              remoteCandidateId: 'xLZB',
+              selected: false,
+              state: 'cancelled',
+              transportId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              writable: true
+            },
+            'Aouc': {
+              id: 'Aouc',
+              timestamp: 1525115247978,
+              type: 'candidatepair',
+              bytesReceived: 0,
+              bytesSent: 0,
+              lastPacketReceivedTimestamp: 0,
+              lastPacketSentTimestamp: 0,
+              localCandidateId: 'QjMi',
+              nominated: false,
+              priority: 3.9607047655352e+17,
+              readable: true,
+              remoteCandidateId: 'xLZB',
+              selected: false,
+              state: 'cancelled',
+              transportId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              writable: true
+            },
+            '6cOO': {
+              id: '6cOO',
+              timestamp: 1525115247978,
+              type: 'candidatepair',
+              bytesReceived: 0,
+              bytesSent: 0,
+              lastPacketReceivedTimestamp: 0,
+              lastPacketSentTimestamp: 0,
+              localCandidateId: 'kCOL',
+              nominated: false,
+              priority: 3.9578900157681e+17,
+              readable: true,
+              remoteCandidateId: 'xLZB',
+              selected: false,
+              state: 'cancelled',
+              transportId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              writable: true
+            },
+            'EwbO': {
+              id: 'EwbO',
+              timestamp: 1525115247978,
+              type: 'candidatepair',
+              bytesReceived: 0,
+              bytesSent: 0,
+              lastPacketReceivedTimestamp: 0,
+              lastPacketSentTimestamp: 0,
+              localCandidateId: 'LsHZ',
+              nominated: false,
+              priority: 3.578250636388e+16,
+              readable: true,
+              remoteCandidateId: 'xLZB',
+              selected: false,
+              state: 'cancelled',
+              transportId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              writable: true
+            },
+            'zTSk': {
+              id: 'zTSk',
+              timestamp: 1525115247978,
+              type: 'candidatepair',
+              bytesReceived: 0,
+              bytesSent: 0,
+              lastPacketReceivedTimestamp: 0,
+              lastPacketSentTimestamp: 0,
+              localCandidateId: 'SwDB',
+              nominated: false,
+              priority: 3.5501031387169e+16,
+              readable: true,
+              remoteCandidateId: 'xLZB',
+              selected: false,
+              state: 'cancelled',
+              transportId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              writable: true
+            },
+            'wJIN': {
+              id: 'wJIN',
+              timestamp: 1525115247978,
+              type: 'localcandidate',
+              candidateType: 'host',
+              componentId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              ipAddress: '10.20.64.226',
+              mozLocalTransport: 'udp',
+              portNumber: 63538,
+              transport: 'udp'
+            },
+            'tbSN': {
+              id: 'tbSN',
+              timestamp: 1525115247978,
+              type: 'localcandidate',
+              candidateType: 'serverreflexive',
+              componentId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              ipAddress: '12.203.65.40',
+              mozLocalTransport: 'udp',
+              portNumber: 38924,
+              transport: 'udp'
+            },
+            'QjMi': {
+              id: 'QjMi',
+              timestamp: 1525115247978,
+              type: 'localcandidate',
+              candidateType: 'relayed',
+              componentId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              ipAddress: '34.203.250.88',
+              mozLocalTransport: 'udp',
+              portNumber: 20479,
+              transport: 'udp'
+            },
+            'eN95': {
+              id: 'eN95',
+              timestamp: 1525115247978,
+              type: 'localcandidate',
+              candidateType: 'host',
+              componentId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              ipAddress: '192.168.209.150',
+              mozLocalTransport: 'udp',
+              portNumber: 61844,
+              transport: 'udp'
+            },
+            'kvar': {
+              id: 'kvar',
+              timestamp: 1525115247978,
+              type: 'localcandidate',
+              candidateType: 'serverreflexive',
+              componentId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              ipAddress: '107.20.226.156',
+              mozLocalTransport: 'udp',
+              portNumber: 61844,
+              transport: 'udp'
+            },
+            'kCOL': {
+              id: 'kCOL',
+              timestamp: 1525115247978,
+              type: 'localcandidate',
+              candidateType: 'relayed',
+              componentId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              ipAddress: '34.203.250.88',
+              mozLocalTransport: 'udp',
+              portNumber: 18838,
+              transport: 'udp'
+            },
+            'VFPG': {
+              id: 'VFPG',
+              timestamp: 1525115247978,
+              type: 'localcandidate',
+              candidateType: 'host',
+              componentId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              ipAddress: '10.20.64.226',
+              mozLocalTransport: 'tcp',
+              portNumber: 53403,
+              transport: 'tcp'
+            },
+            'LsHZ': {
+              id: 'LsHZ',
+              timestamp: 1525115247978,
+              type: 'localcandidate',
+              candidateType: 'relayed',
+              componentId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              ipAddress: '34.203.250.88',
+              mozLocalTransport: 'tls',
+              portNumber: 14806,
+              transport: 'udp'
+            },
+            '8fuV': {
+              id: '8fuV',
+              timestamp: 1525115247978,
+              type: 'localcandidate',
+              candidateType: 'host',
+              componentId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              ipAddress: '192.168.209.150',
+              mozLocalTransport: 'tcp',
+              portNumber: 58132,
+              transport: 'tcp'
+            },
+            'SwDB': {
+              id: 'SwDB',
+              timestamp: 1525115247978,
+              type: 'localcandidate',
+              candidateType: 'relayed',
+              componentId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              ipAddress: '34.203.250.88',
+              mozLocalTransport: 'tls',
+              portNumber: 21154,
+              transport: 'udp'
+            },
+            'xLZB': {
+              id: 'xLZB',
+              timestamp: 1525115247978,
+              type: 'remotecandidate',
+              candidateType: 'host',
+              componentId: '0-1525115182222480 (id=6442450948 url=https://simpler-signaling.appspot.com/) aLevel=0',
+              ipAddress: '10.20.64.226',
+              portNumber: 53508,
+              transport: 'udp'
+            }
+          }
+        };
+
+        var peerConnection = new FakeRTCPeerConnection(options);
+        var { activeIceCandidatePair } = await getStats(peerConnection, { testForFirefox: true });
+
+        var expectedActiveIceCandidatePair = Object.values(options.firefoxFakeStats).find(stat => {
+          return stat.nominated;
+        });
+        var expectedActiveLocalCandidate = options.firefoxFakeStats[expectedActiveIceCandidatePair.localCandidateId];
+        var expectedActiveRemoteCandidate = options.firefoxFakeStats[expectedActiveIceCandidatePair.remoteCandidateId];
+
+        [
+          'availableIncomingBitrate',
+          'availableOutgoingBitrate',
+          'bytesReceived',
+          'bytesSent',
+          'consentRequestsSent',
+          'currentRoundTripTime',
+          'lastPacketReceivedTimestamp',
+          'lastPacketSentTimestamp',
+          'nominated',
+          'priority',
+          'readable',
+          'requestsReceived',
+          'requestsSent',
+          'responsesReceived',
+          'responsesSent',
+          'retransmissionsReceived',
+          'retransmissionsSent',
+          'state',
+          'totalRoundTripTime',
+          'transportId',
+          'writable'
+        ].forEach(key => {
+          assert.equal(activeIceCandidatePair[key], typeof expectedActiveIceCandidatePair[key] !== 'undefined'
+            ? expectedActiveIceCandidatePair[key]
+            :null);
+        });
+
+        [
+          ['candidateType'],
+          ['deleted'],
+          ['ip', 'ipAddress'],
+          ['port', 'portNumber'],
+          ['priority'],
+          ['protocol', 'transport'],
+          ['relayProtocol'],
+          ['url']
+        ].forEach(([key, ffKey]) => {
+          if (key === 'candidateType') {
+            assert.equal(activeIceCandidatePair.localCandidate.candidateType, {
+              host: 'host',
+              peerreflexive: 'prflx',
+              relayed: 'relay',
+              serverreflexive: 'srflx'
+            }[expectedActiveLocalCandidate.candidateType]);
+            return;
+          }
+          assert.equal(activeIceCandidatePair.localCandidate[key], typeof expectedActiveLocalCandidate[ffKey || key] !== 'undefined'
+            ? expectedActiveLocalCandidate[ffKey || key]
+            : key === 'deleted' ? false : null);
+        });
+
+        [
+          ['candidateType'],
+          ['ip', 'ipAddress'],
+          ['port', 'portNumber'],
+          ['priority'],
+          ['protocol', 'transport'],
+          ['url']
+        ].forEach(([key, ffKey]) => {
+          if (key === 'candidateType') {
+            assert.equal(activeIceCandidatePair.remoteCandidate.candidateType, {
+              host: 'host',
+              peerreflexive: 'prflx',
+              relayed: 'relay',
+              serverreflexive: 'srflx'
+            }[expectedActiveRemoteCandidate.candidateType]);
+            return;
+          }
+          assert.equal(activeIceCandidatePair.remoteCandidate[key], typeof expectedActiveRemoteCandidate[ffKey || key] !== 'undefined'
+            ? expectedActiveRemoteCandidate[ffKey || key]
+            : null);
+        });
+      });
+    });
   });
 });

--- a/test/unit/spec/getstats.js
+++ b/test/unit/spec/getstats.js
@@ -269,7 +269,7 @@ describe('getStats', function() {
   describe('Active RTCIceCandidate pair stats', () => {
     context('should be present in StandardizedStatsResponse for', () => {
       it('chrome', async () => {
-        var options = {
+        const options = {
           chromeFakeStats: {},
           chromeFakeIceStats: [
             {
@@ -418,16 +418,16 @@ describe('getStats', function() {
             }
           ]
         };
-        var peerConnection = new FakeRTCPeerConnection(options);
-        var { activeIceCandidatePair } = await getStats(peerConnection, { testForChrome: true });
+        const peerConnection = new FakeRTCPeerConnection(options);
+        const { activeIceCandidatePair } = await getStats(peerConnection, { testForChrome: true });
 
-        var expectedActiveIceCandidatePair = options.chromeFakeIceStats.find(stat => {
+        const expectedActiveIceCandidatePair = options.chromeFakeIceStats.find(stat => {
           return stat.nominated;
         });
-        var expectedActiveLocalCandidate = options.chromeFakeIceStats.find(stat => {
+        const expectedActiveLocalCandidate = options.chromeFakeIceStats.find(stat => {
           return stat.id === expectedActiveIceCandidatePair.localCandidateId;
         });
-        var expectedActiveRemoteCandidate = options.chromeFakeIceStats.find(stat => {
+        const expectedActiveRemoteCandidate = options.chromeFakeIceStats.find(stat => {
           return stat.id === expectedActiveIceCandidatePair.remoteCandidateId;
         });
 
@@ -456,7 +456,7 @@ describe('getStats', function() {
         ].forEach(key => {
           assert.equal(activeIceCandidatePair[key], typeof expectedActiveIceCandidatePair[key] !== 'undefined'
             ? expectedActiveIceCandidatePair[key]
-            :null);
+            : null);
         });
 
         [
@@ -489,7 +489,7 @@ describe('getStats', function() {
       });
 
       it('firefox', async () => {
-        var options = {
+        const options = {
           firefoxFakeStats: {
             'Gmx9': {
               id: 'Gmx9',
@@ -722,14 +722,14 @@ describe('getStats', function() {
           }
         };
 
-        var peerConnection = new FakeRTCPeerConnection(options);
-        var { activeIceCandidatePair } = await getStats(peerConnection, { testForFirefox: true });
+        const peerConnection = new FakeRTCPeerConnection(options);
+        const { activeIceCandidatePair } = await getStats(peerConnection, { testForFirefox: true });
 
-        var expectedActiveIceCandidatePair = Object.values(options.firefoxFakeStats).find(stat => {
+        const expectedActiveIceCandidatePair = Object.values(options.firefoxFakeStats).find(stat => {
           return stat.nominated;
         });
-        var expectedActiveLocalCandidate = options.firefoxFakeStats[expectedActiveIceCandidatePair.localCandidateId];
-        var expectedActiveRemoteCandidate = options.firefoxFakeStats[expectedActiveIceCandidatePair.remoteCandidateId];
+        const expectedActiveLocalCandidate = options.firefoxFakeStats[expectedActiveIceCandidatePair.localCandidateId];
+        const expectedActiveRemoteCandidate = options.firefoxFakeStats[expectedActiveIceCandidatePair.remoteCandidateId];
 
         [
           'availableIncomingBitrate',
@@ -756,7 +756,7 @@ describe('getStats', function() {
         ].forEach(key => {
           assert.equal(activeIceCandidatePair[key], typeof expectedActiveIceCandidatePair[key] !== 'undefined'
             ? expectedActiveIceCandidatePair[key]
-            :null);
+            : null);
         });
 
         [


### PR DESCRIPTION
@markandrus 

This PR adds support for `getStats()` to return stats for the active RTCIceCandidate pair.

TODO:
=====

Integration tests