### PR TITLE
Allow passing Chrome-specific constraints

### DIFF
--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -25,9 +25,9 @@ var PeerConnection = typeof RTCPeerConnection !== 'undefined'
 //
 //   3. Set iceTransportPolicy.
 //
-function ChromeRTCPeerConnection(configuration) {
+function ChromeRTCPeerConnection(configuration, constraints) {
   if (!(this instanceof ChromeRTCPeerConnection)) {
-    return new ChromeRTCPeerConnection(configuration);
+    return new ChromeRTCPeerConnection(configuration, constraints);
   }
 
   EventTarget.call(this);
@@ -48,7 +48,7 @@ function ChromeRTCPeerConnection(configuration) {
   util.interceptEvent(this, 'track');
 
   /* eslint new-cap:0 */
-  var peerConnection = new PeerConnection(newConfiguration);
+  var peerConnection = new PeerConnection(newConfiguration, constraints);
 
   Object.defineProperties(this, {
     _localStream: {


### PR DESCRIPTION
In Chrome, the RTCPeerConnection constructor accepts a second argument. It's not specced in Web IDL, AFAICT, but in the C++, it's some instance of `webrtc::MediaConstraintsInterface`. So I've called it `constraints` here. This parameter allows specifying some Chrome-specific settings, such as those specified by Google Hangouts. For example,

```js
new RTCPeerConnection(configuration, {
  mandatory: {
    googCpuOveruseDetection: true,
    googCpuOveruseThreshold: 85,
    googCpuUnderuseThreshold: 55
  }
});
```

I would like us to add support for `constraints` so that libraries like twilio-video.js can experiment with these options.