### PR TITLE
Prepare for 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
-2.0.1 (In progress)
-===================
+2.1.0 (July 3, 2018)
+====================
 
 New Features
 ------------
 
 - `StandardizedStatsResponse` has a new property `.activeIceCandidatePair`,
   which contains the normalized active ICE candidate pair statistics.
+- Added support for passing Chrome-specific constraints.
 
 2.0.0 (January 9, 2018)
 =======================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twilio/webrtc",
-  "version": "2.0.1-dev",
+  "version": "2.1.0-dev",
   "description": "WebRTC-related APIs and shims used by twilio-video.js",
   "scripts": {
     "build": "npm-run-all clean lint test",


### PR DESCRIPTION
@manjeshbhargav I changed 2.0.1 to 2.1.0 because we actually have new features, therefore we must bump the minor version number.