### PR TITLE
Fix up SSRCs in createAnswer, not just createOffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+2.1.1 (in progress)
+===================
+
+Bug Fixes
+---------
+
+- Fixed a bug in the management of SSRCs in Chrome. (JSDK-2032)
+
 2.1.0 (July 3, 2018)
 ====================
 

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -255,20 +255,26 @@ ChromeRTCPeerConnection.prototype.createAnswer = function createAnswer() {
       return self._peerConnection.createAnswer();
     }).then(function createAnswerSucceeded(answer) {
       self._pendingRemoteOffer = null;
-      return answer;
+      return new RTCSessionDescription({
+        type: 'answer',
+        sdp: updateTracksToSSRCs(self._tracksToSSRCs, answer.sdp)
+      });
     }, function setRemoteDescriptionOrCreateAnswerFailed(error) {
       self._pendingRemoteOffer = null;
       throw error;
     });
+  } else {
+    promise = this._peerConnection.createAnswer().then(function(answer) {
+      return new RTCSessionDescription({
+        type: 'answer',
+        sdp: updateTracksToSSRCs(self._tracksToSSRCs, answer.sdp)
+      });
+    });
   }
 
-  if (promise) {
-    return args.length > 1
-      ? util.legacyPromise(promise, args[0], args[1])
-      : promise;
-  }
-
-  return this._peerConnection.createAnswer.apply(this._peerConnection, args);
+  return args.length > 1
+    ? util.legacyPromise(promise, args[0], args[1])
+    : promise;
 };
 
 ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {


### PR DESCRIPTION
It took a bit of digging, but I realized the crash in JSDK-2032 was due in part to the fact that we do not perform the "SSRC fix" in `createAnswer`, only `createOffer`. For context: the "SSRC fix" involves overwriting SSRCs generated by the RTCPeerConnection such that, no matter how many times you call `createOffer`/`createAnswer` (irrespective of `setLocalDescription`), the same SSRCs will be used. Why do we want to do this? Well, Chrome can act weirdly when SSRCs are changed (it may raise a new MediaStreamTrack upon SSRC change for example). See [here](https://bugs.chromium.org/p/webrtc/issues/detail?id=5208) and [here](https://bugs.chromium.org/p/webrtc/issues/detail?id=1817) for related bugs.

Anyway, my (difficult to test) hypothesis is that our failure to fix up the SSRC mis-interacts with our simulcast code in twilio-video.js (this caused two SIM groups to be inserted), which eventually crashes the tab. This only happens when glare occurs and we're adding SSRCs in an answer.