### PR TITLE
JSDK-1227: Fix getStats api deprecated warnings in firefox

### DIFF
--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -169,7 +169,7 @@ function standardizeChromeActiveIceCandidatePairStats(stats) {
  * @returns {?StandardizedActiveIceCandidatePairStatsReport}
  */
 function standardizeFirefoxActiveIceCandidatePairStats(stats) {
-  var activeCandidatePairStats = Object.values(stats).find(function(stat) {
+  var activeCandidatePairStats = Array.from(stats.values()).find(function(stat) {
     return stat.type === 'candidatepair' && stat.nominated;
   });
 
@@ -177,8 +177,8 @@ function standardizeFirefoxActiveIceCandidatePairStats(stats) {
     return null;
   }
 
-  var activeLocalCandidateStats = stats[activeCandidatePairStats.localCandidateId];
-  var activeRemoteCandidateStats = stats[activeCandidatePairStats.remoteCandidateId];
+  var activeLocalCandidateStats = stats.get(activeCandidatePairStats.localCandidateId);
+  var activeRemoteCandidateStats = stats.get(activeCandidatePairStats.remoteCandidateId);
 
   var standardizedCandidateStatsKeys = [
     { key: 'candidateType', type: 'string' },
@@ -324,7 +324,7 @@ function chromeGetTrackStats(peerConnection, track) {
  */
 function firefoxGetTrackStats(peerConnection, track) {
   return new Promise(function(resolve, reject) {
-    peerConnection.getStats(track, function(response) {
+    peerConnection.getStats(track).then(function(response) {
       resolve(standardizeFirefoxStats(response));
     }, reject);
   });
@@ -416,15 +416,15 @@ function standardizeFirefoxStats(response) {
   //
   //   https://bugzilla.mozilla.org/show_bug.cgi?id=1377225
   //
-  response = response || {};
+  response = response || { values: function() { return []; } };
 
-  var inbound = Object.keys(response).reduce(function(report, id) {
-    return response[id].type === 'inboundrtp' ? response[id] : report;
-  }, null);
+  var inbound = Array.from(response.values()).find(function(stat) {
+    return stat.type === 'inboundrtp';
+  });
 
-  var outbound = Object.keys(response).reduce(function(report, id) {
-    return response[id].type === 'outboundrtp' ? response[id] : report;
-  }, null);
+  var outbound = Array.from(response.values()).find(function(stat) {
+    return stat.type === 'outboundrtp';
+  });
 
   var standardizedStats = {};
 

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -170,7 +170,7 @@ function standardizeChromeActiveIceCandidatePairStats(stats) {
  */
 function standardizeFirefoxActiveIceCandidatePairStats(stats) {
   var activeCandidatePairStats = Array.from(stats.values()).find(function(stat) {
-    return stat.type === 'candidatepair' && stat.nominated;
+    return stat.type === 'candidate-pair' && stat.nominated;
   });
 
   if (!activeCandidatePairStats) {
@@ -416,7 +416,7 @@ function standardizeFirefoxStats(response) {
   //
   //   https://bugzilla.mozilla.org/show_bug.cgi?id=1377225
   //
-  response = response || { values: function() { return []; } };
+  response = response || new Map();
 
   var inbound = Array.from(response.values()).find(function(stat) {
     return stat.type === 'inboundrtp';

--- a/test/unit/spec/getstats.js
+++ b/test/unit/spec/getstats.js
@@ -494,7 +494,7 @@ describe('getStats', function() {
             'Gmx9': {
               id: 'Gmx9',
               timestamp: 1525115247978,
-              type: 'candidatepair',
+              type: 'candidate-pair',
               bytesReceived: 591211,
               bytesSent: 591293,
               lastPacketReceivedTimestamp: 1525115247973,
@@ -512,7 +512,7 @@ describe('getStats', function() {
             '9NHy': {
               id: '9NHy',
               timestamp: 1525115247978,
-              type: 'candidatepair',
+              type: 'candidate-pair',
               bytesReceived: 0,
               bytesSent: 0,
               lastPacketReceivedTimestamp: 0,
@@ -530,7 +530,7 @@ describe('getStats', function() {
             'Aouc': {
               id: 'Aouc',
               timestamp: 1525115247978,
-              type: 'candidatepair',
+              type: 'candidate-pair',
               bytesReceived: 0,
               bytesSent: 0,
               lastPacketReceivedTimestamp: 0,
@@ -548,7 +548,7 @@ describe('getStats', function() {
             '6cOO': {
               id: '6cOO',
               timestamp: 1525115247978,
-              type: 'candidatepair',
+              type: 'candidate-pair',
               bytesReceived: 0,
               bytesSent: 0,
               lastPacketReceivedTimestamp: 0,
@@ -566,7 +566,7 @@ describe('getStats', function() {
             'EwbO': {
               id: 'EwbO',
               timestamp: 1525115247978,
-              type: 'candidatepair',
+              type: 'candidate-pair',
               bytesReceived: 0,
               bytesSent: 0,
               lastPacketReceivedTimestamp: 0,
@@ -584,7 +584,7 @@ describe('getStats', function() {
             'zTSk': {
               id: 'zTSk',
               timestamp: 1525115247978,
-              type: 'candidatepair',
+              type: 'candidate-pair',
               bytesReceived: 0,
               bytesSent: 0,
               lastPacketReceivedTimestamp: 0,

--- a/test/unit/spec/getstats.js
+++ b/test/unit/spec/getstats.js
@@ -142,7 +142,7 @@ describe('getStats', function() {
 
   it('should resolve the promise with a StandardizedStatsResponse in Firefox (outbound)', () => {
     var options = {
-      firefoxFakeStats: {
+      firefoxFakeStats: new Map(Object.entries({
         outbound_rtcp_media_0: {
           timestamp: 12345,
           type: 'inboundrtp',
@@ -163,10 +163,10 @@ describe('getStats', function() {
           packetsSent: 50,
           framerateMean: 28.84
         }
-      }
+      }))
     };
-    var fakeInbound = options.firefoxFakeStats.outbound_rtcp_media_0;
-    var fakeOutbound = options.firefoxFakeStats.outbound_rtp_media_0;
+    var fakeInbound = options.firefoxFakeStats.get('outbound_rtcp_media_0');
+    var fakeOutbound = options.firefoxFakeStats.get('outbound_rtp_media_0');
     var peerConnection = new FakeRTCPeerConnection(options);
     var localStream = new FakeMediaStream();
     var remoteStream = new FakeMediaStream();
@@ -206,7 +206,7 @@ describe('getStats', function() {
 
   it('should resolve the promise with a StandardizedStatsResponse in Firefox (inbound)', () => {
     var options = {
-      firefoxFakeStats: {
+      firefoxFakeStats: new Map(Object.entries({
         inbound_rtcp_media_0: {
           timestamp: 12345,
           type: 'outboundrtp',
@@ -226,10 +226,10 @@ describe('getStats', function() {
           jitter: 0.05,
           framerateMean: 20.45
         }
-      }
+      }))
     };
-    var fakeInbound = options.firefoxFakeStats.inbound_rtp_media_0;
-    var fakeOutbound = options.firefoxFakeStats.inbound_rtcp_media_0;
+    var fakeInbound = options.firefoxFakeStats.get('inbound_rtp_media_0');
+    var fakeOutbound = options.firefoxFakeStats.get('inbound_rtcp_media_0');
     var peerConnection = new FakeRTCPeerConnection(options);
     var localStream = new FakeMediaStream();
     var remoteStream = new FakeMediaStream();
@@ -490,7 +490,7 @@ describe('getStats', function() {
 
       it('firefox', async () => {
         const options = {
-          firefoxFakeStats: {
+          firefoxFakeStats: new Map(Object.entries({
             'Gmx9': {
               id: 'Gmx9',
               timestamp: 1525115247978,
@@ -719,17 +719,17 @@ describe('getStats', function() {
               portNumber: 53508,
               transport: 'udp'
             }
-          }
+          }))
         };
 
         const peerConnection = new FakeRTCPeerConnection(options);
         const { activeIceCandidatePair } = await getStats(peerConnection, { testForFirefox: true });
 
-        const expectedActiveIceCandidatePair = Object.values(options.firefoxFakeStats).find(stat => {
+        const expectedActiveIceCandidatePair = Array.from(options.firefoxFakeStats.values()).find(stat => {
           return stat.nominated;
         });
-        const expectedActiveLocalCandidate = options.firefoxFakeStats[expectedActiveIceCandidatePair.localCandidateId];
-        const expectedActiveRemoteCandidate = options.firefoxFakeStats[expectedActiveIceCandidatePair.remoteCandidateId];
+        const expectedActiveLocalCandidate = options.firefoxFakeStats.get(expectedActiveIceCandidatePair.localCandidateId);
+        const expectedActiveRemoteCandidate = options.firefoxFakeStats.get(expectedActiveIceCandidatePair.remoteCandidateId);
 
         [
           'availableIncomingBitrate',


### PR DESCRIPTION
@manjeshbhargav @markandrus 
Please review the PR while I am looking into one of the integration test failures in firefox.