### PR TITLE
Use hyphenated rtc stat types for firefox

### DIFF
--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -419,11 +419,11 @@ function standardizeFirefoxStats(response) {
   response = response || new Map();
 
   var inbound = Array.from(response.values()).find(function(stat) {
-    return stat.type === 'inboundrtp';
+    return stat.type === 'inbound-rtp';
   });
 
   var outbound = Array.from(response.values()).find(function(stat) {
-    return stat.type === 'outboundrtp';
+    return stat.type === 'outbound-rtp';
   });
 
   var standardizedStats = {};

--- a/test/unit/spec/getstats.js
+++ b/test/unit/spec/getstats.js
@@ -145,7 +145,7 @@ describe('getStats', function() {
       firefoxFakeStats: new Map(Object.entries({
         outbound_rtcp_media_0: {
           timestamp: 12345,
-          type: 'inboundrtp',
+          type: 'inbound-rtp',
           isRemote: true,
           ssrc: 'foo',
           bytesReceived: 100,
@@ -156,7 +156,7 @@ describe('getStats', function() {
         },
         outbound_rtp_media_0: {
           timestamp: 67890,
-          type: 'outboundrtp',
+          type: 'outbound-rtp',
           isRemote: false,
           ssrc: 'foo',
           bytesSent: 45,
@@ -209,7 +209,7 @@ describe('getStats', function() {
       firefoxFakeStats: new Map(Object.entries({
         inbound_rtcp_media_0: {
           timestamp: 12345,
-          type: 'outboundrtp',
+          type: 'outbound-rtp',
           isRemote: true,
           ssrc: 'foo',
           bytesSent: 100,
@@ -217,7 +217,7 @@ describe('getStats', function() {
         },
         inbound_rtp_media_0: {
           timestamp: 67890,
-          type: 'inboundrtp',
+          type: 'inbound-rtp',
           isRemote: false,
           ssrc: 'foo',
           bytesReceived: 45,


### PR DESCRIPTION
@markandrus @manjeshbhargav 
This should fix the null values in stats report in firefox.