### PR TITLE
Introduce RTCPeerConnection Shim for Edge 

### DIFF
--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -30,7 +30,7 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
         throw new Error('Unknown browser');
       }
     } else if (process.platform === 'darwin') {
-      browsers = ['ChromeWebRTC', 'FirefoxWebRTC', 'SafariTechPreview'];
+      browsers = ['ChromeWebRTC', 'FirefoxWebRTC', 'Safari'];
     } else {
       browsers = ['ChromeWebRTC', 'FirefoxWebRTC'];
     }

--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -20,7 +20,8 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
     let browsers = {
       chrome: ['ChromeWebRTC'],
       firefox: ['FirefoxWebRTC'],
-      safari: ['Safari']
+      safari: ['Safari'],
+      edge: ['Edge']
     };
 
     if (process.env.BROWSER) {

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -72,13 +72,11 @@ function getActiveIceCandidatePairStats(peerConnection, options) {
 
   var browser = guessBrowser();
 
-  if (browser === 'chrome' || typeof options.testForChrome !== 'undefined') {
+  if (browser === 'chrome' || options.testForChrome) {
     return peerConnection.getStats().then(standardizeChromeActiveIceCandidatePairStats);
   }
-  if (browser === 'firefox'
-    || browser === 'edge'
-    || typeof options.testForFirefox  !== 'undefined'
-    || typeof options.testForEdge  !== 'undefined') {
+  if (browser === 'firefox' || options.testForFirefox
+    || browser === 'edge' || options.testForEdge) {
     return peerConnection.getStats().then(standardizeEdgeAndFirefoxActiveIceCandidatePairStats);
   }
 
@@ -168,12 +166,11 @@ function standardizeChromeActiveIceCandidatePairStats(stats) {
 }
 
 /**
- * Standardize the active RTCIceCandidate pair's statistics in Firefox.
+ * Standardize the active RTCIceCandidate pair's statistics in Firefox/Edge.
  * @param {RTCStatsReport} stats
  * @returns {?StandardizedActiveIceCandidatePairStatsReport}
  */
 function standardizeEdgeAndFirefoxActiveIceCandidatePairStats(stats) {
-
   var activeCandidatePairStats = Array.from(stats.values()).find(function(stat) {
     return stat.type === 'candidate-pair' && stat.nominated;
   });
@@ -297,13 +294,13 @@ function getTrackStats(peerConnection, track, options) {
   options = options || {};
   var browser = guessBrowser();
 
-  if (browser === 'chrome' || typeof options.testForChrome !== 'undefined') {
+  if (browser === 'chrome' || options.testForChrome) {
     return chromeGetTrackStats(peerConnection, track);
   }
-  if (browser === 'firefox' || typeof options.testForFirefox  !== 'undefined') {
+  if (browser === 'firefox' || options.testForFirefox) {
     return firefoxGetTrackStats(peerConnection, track);
   }
-  if (browser === 'edge' || typeof options.testForEdge  !== 'undefined') {
+  if (browser === 'edge' || options.testForEdge) {
     return edgeGetTrackStats(peerConnection, track);
   }
   return Promise.reject(new Error('RTCPeerConnection#getStats() not supported'));
@@ -330,6 +327,8 @@ function chromeGetTrackStats(peerConnection, track) {
  * @returns {Promise.<StandardizedTrackStatsReport>}
  */
 function edgeGetTrackStats(peerConnection, track) {
+  // Note(syerrapragada): getStats Promise is rejected if ice state is not completed
+  // https://msdn.microsoft.com/en-us/library/mt599588(v=vs.85).aspx
   return waitForEdgeIceCompletion(peerConnection).then(function() {
     return peerConnection.getStats(track);
   }).then(function(response) {
@@ -337,22 +336,27 @@ function edgeGetTrackStats(peerConnection, track) {
   });
 }
 
+/**
+ * Waits for ice connection state is completed or failed.
+ *
+ * @param {RTCPeerConnection} peerConnection
+ * @returns {Promise<void>}
+ */
 function waitForEdgeIceCompletion(peerConnection) {
-  const iceConnectionStatesToWait = new Set(['checking', 'connected', 'new']);
-  if (!iceConnectionStatesToWait.has(peerConnection.iceConnectionState)) {
-    return Promise.resolve();
-  }
-  return new Promise(function(resolve, reject) {
-    const timeoutToFail = setTimeout(reject, 5000, new Error('failed'));
-    peerConnection.addEventListener('iceconnectionstatechange', function onIceConnectionStateChanged() {
-      const iceConnectionStatesToResolve = new Set(['completed', 'failed']);
-      if (iceConnectionStatesToResolve.has(peerConnection.iceConnectionState)) {
-        clearTimeout(timeoutToFail);
-        peerConnection.removeEventListener('iceconnectionstatechange', onIceConnectionStateChanged);
-        setTimeout(resolve, 4000);
-      }
+  if (peerConnection.iceConnectionState === 'new'
+    || peerConnection.iceConnectionState === 'checking'
+    || peerConnection.iceConnectionState === 'connected') {
+    return new Promise(function(resolve) {
+      peerConnection.addEventListener('iceconnectionstatechange', function onIceConnectionStateChanged() {
+        if (peerConnection.iceConnectionState === 'completed' || peerConnection.iceConnectionState === 'failed') {
+          peerConnection.removeEventListener('iceconnectionstatechange', onIceConnectionStateChanged);
+          // Note(syerrapragada): Without 1s delay I don't see stats on Edge
+          setTimeout(resolve, 1000);
+        }
+      });
     });
-  });
+  }
+  return Promise.resolve();
 }
 
 /**
@@ -444,7 +448,7 @@ function standardizeChromeStats(response, track) {
 }
 
 /**
- * Standardize the MediaStreamTrack's statistics in Firefox.
+ * Standardize the MediaStreamTrack's statistics in Firefox/Edge.
  * @param {RTCStatsReport} response
  * @returns {StandardizedTrackStatsReport}
  */

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -75,7 +75,10 @@ function getActiveIceCandidatePairStats(peerConnection, options) {
   if (browser === 'chrome' || typeof options.testForChrome !== 'undefined') {
     return peerConnection.getStats().then(standardizeChromeActiveIceCandidatePairStats);
   }
-  if (browser === 'firefox' || browser === 'edge' || typeof options.testForFirefox  !== 'undefined') {
+  if (browser === 'firefox'
+    || browser === 'edge'
+    || typeof options.testForFirefox  !== 'undefined'
+    || typeof options.testForEdge  !== 'undefined') {
     return peerConnection.getStats().then(standardizeFirefoxActiveIceCandidatePairStats);
   }
 
@@ -327,31 +330,28 @@ function chromeGetTrackStats(peerConnection, track) {
  * @returns {Promise.<StandardizedTrackStatsReport>}
  */
 function edgeGetTrackStats(peerConnection, track) {
-  return new Promise(function(resolve, reject) {
-    waitForEdgeIceCompletion(peerConnection).then(function() {
-      peerConnection.getStats(track).then(function(response) {
-        resolve(standardizeFirefoxStats(response));
-      }, reject);
-    });
+  return waitForEdgeIceCompletion(peerConnection).then(function() {
+    return peerConnection.getStats(track);
+  }).then(function(response) {
+    return standardizeEdgeAndFirefoxStats(response);
   });
 }
 
 function waitForEdgeIceCompletion(peerConnection) {
-  return new Promise(function(resolve) {
-    if (peerConnection.iceConnectionState === 'new'
-      || peerConnection.iceConnectionState === 'checking'
-      || peerConnection.iceConnectionState === 'connected') {
-
-      peerConnection.addEventListener('iceconnectionstatechange', function handleEvent() {
-        if (peerConnection.iceConnectionState === 'completed' || peerConnection.iceConnectionState === 'failed') {
-          peerConnection.removeEventListener('iceconnectionstatechange', handleEvent);
-          setTimeout(resolve, 4000);
-        }
-      });
-
-    } else {
-      resolve();
-    }
+  const iceConnectionStatesToWait = new Set(['checking', 'connected', 'new']);
+  if (!iceConnectionStatesToWait.has(peerConnection.iceConnectionState)) {
+    return Promise.resolve();
+  }
+  return new Promise(function(resolve, reject) {
+    const timeoutToFail = setTimeout(reject, FAIL_DELAY, new Error('failed'));
+    peerConnection.addEventListener('iceconnectionstatechange', function onIceConnectionStateChanged() {
+      const iceConnectionStatesToResolve = new Set(['completed', 'failed']);
+      if (iceConnectionStatesToResolve.has(peerConnection.iceConnectionState)) {
+        clearTimeout(timeoutToFail);
+        peerConnection.removeEventListener('iceconnectionstatechange', onIceConnectionStateChanged);
+        setTimeout(resolve, 4000);
+      }
+    });
   });
 }
 
@@ -448,7 +448,7 @@ function standardizeChromeStats(response, track) {
  * @param {RTCStatsReport} response
  * @returns {StandardizedTrackStatsReport}
  */
-function standardizeFirefoxStats(response) {
+function standardizeEdgeAndFirefoxStats(response) {
   // NOTE(mroberts): If getStats is called on a closed RTCPeerConnection,
   // Firefox returns undefined instead of an RTCStatsReport. We workaround this
   // here. See the following bug for more details:

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -79,7 +79,7 @@ function getActiveIceCandidatePairStats(peerConnection, options) {
     || browser === 'edge'
     || typeof options.testForFirefox  !== 'undefined'
     || typeof options.testForEdge  !== 'undefined') {
-    return peerConnection.getStats().then(standardizeFirefoxActiveIceCandidatePairStats);
+    return peerConnection.getStats().then(standardizeEdgeAndFirefoxActiveIceCandidatePairStats);
   }
 
   return Promise.reject(new Error('RTCPeerConnection#getStats() not supported'));
@@ -172,7 +172,7 @@ function standardizeChromeActiveIceCandidatePairStats(stats) {
  * @param {RTCStatsReport} stats
  * @returns {?StandardizedActiveIceCandidatePairStatsReport}
  */
-function standardizeFirefoxActiveIceCandidatePairStats(stats) {
+function standardizeEdgeAndFirefoxActiveIceCandidatePairStats(stats) {
 
   var activeCandidatePairStats = Array.from(stats.values()).find(function(stat) {
     return stat.type === 'candidate-pair' && stat.nominated;
@@ -343,7 +343,7 @@ function waitForEdgeIceCompletion(peerConnection) {
     return Promise.resolve();
   }
   return new Promise(function(resolve, reject) {
-    const timeoutToFail = setTimeout(reject, FAIL_DELAY, new Error('failed'));
+    const timeoutToFail = setTimeout(reject, 5000, new Error('failed'));
     peerConnection.addEventListener('iceconnectionstatechange', function onIceConnectionStateChanged() {
       const iceConnectionStatesToResolve = new Set(['completed', 'failed']);
       if (iceConnectionStatesToResolve.has(peerConnection.iceConnectionState)) {
@@ -364,7 +364,7 @@ function waitForEdgeIceCompletion(peerConnection) {
 function firefoxGetTrackStats(peerConnection, track) {
   return new Promise(function(resolve, reject) {
     peerConnection.getStats(track).then(function(response) {
-      resolve(standardizeFirefoxStats(response));
+      resolve(standardizeEdgeAndFirefoxStats(response));
     }, reject);
   });
 }

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -327,7 +327,7 @@ function chromeGetTrackStats(peerConnection, track) {
  * @returns {Promise.<StandardizedTrackStatsReport>}
  */
 function edgeGetTrackStats(peerConnection, track) {
-  // Note(syerrapragada): getStats Promise is rejected if ice state is not completed
+  // NOTE(syerrapragada): getStats Promise is rejected if ice state is not completed
   // https://msdn.microsoft.com/en-us/library/mt599588(v=vs.85).aspx
   return waitForEdgeIceCompletion(peerConnection).then(function() {
     return peerConnection.getStats(track);
@@ -350,7 +350,7 @@ function waitForEdgeIceCompletion(peerConnection) {
       peerConnection.addEventListener('iceconnectionstatechange', function onIceConnectionStateChanged() {
         if (peerConnection.iceConnectionState === 'completed' || peerConnection.iceConnectionState === 'failed') {
           peerConnection.removeEventListener('iceconnectionstatechange', onIceConnectionStateChanged);
-          // Note(syerrapragada): Without 1s delay I don't see stats on Edge
+          // NOTE(syerrapragada): Without 1s delay I don't see stats on Edge
           setTimeout(resolve, 1000);
         }
       });

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -1,4 +1,3 @@
-/* global webkitRTCPeerConnection, mozRTCPeerConnection */
 'use strict';
 
 var flatMap = require('./util').flatMap;
@@ -333,17 +332,17 @@ function edgeGetTrackStats(peerConnection, track) {
       peerConnection.getStats(track).then(function(response) {
         resolve(standardizeFirefoxStats(response));
       }, reject);
-    })
+    });
   });
 }
 
 function waitForEdgeIceCompletion(peerConnection) {
-  return new Promise(function(resolve, reject) {
+  return new Promise(function(resolve) {
     if (peerConnection.iceConnectionState === 'new'
       || peerConnection.iceConnectionState === 'checking'
       || peerConnection.iceConnectionState === 'connected') {
 
-      peerConnection.addEventListener('iceconnectionstatechange', function handleEvent(event) {
+      peerConnection.addEventListener('iceconnectionstatechange', function handleEvent() {
         if (peerConnection.iceConnectionState === 'completed' || peerConnection.iceConnectionState === 'failed') {
           peerConnection.removeEventListener('iceconnectionstatechange', handleEvent);
           setTimeout(resolve, 4000);

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -348,8 +348,8 @@ function waitForEdgeIceCompletion(peerConnection) {
       peerConnection.addEventListener('iceconnectionstatechange', function onIceConnectionStateChanged() {
         if (peerConnection.iceConnectionState === 'completed' || peerConnection.iceConnectionState === 'failed') {
           peerConnection.removeEventListener('iceconnectionstatechange', onIceConnectionStateChanged);
-          // NOTE(syerrapragada): Without 1s delay I don't see stats on Edge
-          setTimeout(resolve, 1000);
+          // NOTE(syerrapragada): Without a 250ms delay getStats method returns a promise that is rejected
+          setTimeout(resolve, 250);
         }
       });
     });

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -331,9 +331,7 @@ function edgeGetTrackStats(peerConnection, track) {
   // https://msdn.microsoft.com/en-us/library/mt599588(v=vs.85).aspx
   return waitForEdgeIceCompletion(peerConnection).then(function() {
     return peerConnection.getStats(track);
-  }).then(function(response) {
-    return standardizeEdgeAndFirefoxStats(response);
-  });
+  }).then(standardizeEdgeAndFirefoxStats);
 }
 
 /**

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var flatMap = require('./util').flatMap;
+var guessBrowser = require('./util').guessBrowser;
 
 /**
  * Get the standardized {@link RTCPeerConnection} statistics.
@@ -70,14 +71,15 @@ function _getStats(peerConnection, options) {
 function getActiveIceCandidatePairStats(peerConnection, options) {
   options = options || {};
 
-  if (typeof options.testForChrome !== 'undefined'
-    || typeof webkitRTCPeerConnection !== 'undefined') {
+  var browser = guessBrowser();
+
+  if (browser === 'chrome' || typeof options.testForChrome !== 'undefined') {
     return peerConnection.getStats().then(standardizeChromeActiveIceCandidatePairStats);
   }
-  if (typeof options.testForFirefox !== 'undefined'
-    || typeof mozRTCPeerConnection !== 'undefined') {
+  if (browser === 'firefox' || browser === 'edge' || typeof options.testForFirefox  !== 'undefined') {
     return peerConnection.getStats().then(standardizeFirefoxActiveIceCandidatePairStats);
   }
+
   return Promise.reject(new Error('RTCPeerConnection#getStats() not supported'));
 }
 
@@ -169,6 +171,7 @@ function standardizeChromeActiveIceCandidatePairStats(stats) {
  * @returns {?StandardizedActiveIceCandidatePairStatsReport}
  */
 function standardizeFirefoxActiveIceCandidatePairStats(stats) {
+
   var activeCandidatePairStats = Array.from(stats.values()).find(function(stat) {
     return stat.type === 'candidate-pair' && stat.nominated;
   });
@@ -290,14 +293,16 @@ function getTracks(peerConnection, kind, localOrRemote) {
  */
 function getTrackStats(peerConnection, track, options) {
   options = options || {};
+  var browser = guessBrowser();
 
-  if (typeof options.testForChrome !== 'undefined' ||
-    typeof webkitRTCPeerConnection !== 'undefined') {
+  if (browser === 'chrome' || typeof options.testForChrome !== 'undefined') {
     return chromeGetTrackStats(peerConnection, track);
   }
-  if (typeof options.testForFirefox  !== 'undefined' ||
-    typeof mozRTCPeerConnection !== 'undefined') {
+  if (browser === 'firefox' || typeof options.testForFirefox  !== 'undefined') {
     return firefoxGetTrackStats(peerConnection, track);
+  }
+  if (browser === 'edge') {
+    return edgeGetTrackStats(peerConnection, track);
   }
   return Promise.reject(new Error('RTCPeerConnection#getStats() not supported'));
 }
@@ -313,6 +318,41 @@ function chromeGetTrackStats(peerConnection, track) {
     peerConnection.getStats(function(response) {
       resolve(standardizeChromeStats(response, track));
     }, null, reject);
+  });
+}
+
+/**
+ * Get the standardized statistics for a particular MediaStreamTrack in Edge.
+ * @param {RTCPeerConnection} peerConnection
+ * @param {MediaStreamTrack} track
+ * @returns {Promise.<StandardizedTrackStatsReport>}
+ */
+function edgeGetTrackStats(peerConnection, track) {
+  return new Promise(function(resolve, reject) {
+    waitForEdgeIceCompletion(peerConnection).then(function() {
+      peerConnection.getStats(track).then(function(response) {
+        resolve(standardizeFirefoxStats(response));
+      }, reject);
+    })
+  });
+}
+
+function waitForEdgeIceCompletion(peerConnection) {
+  return new Promise(function(resolve, reject) {
+    if (peerConnection.iceConnectionState === 'new'
+      || peerConnection.iceConnectionState === 'checking'
+      || peerConnection.iceConnectionState === 'connected') {
+
+      peerConnection.addEventListener('iceconnectionstatechange', function handleEvent(event) {
+        if (peerConnection.iceConnectionState === 'completed' || peerConnection.iceConnectionState === 'failed') {
+          peerConnection.removeEventListener('iceconnectionstatechange', handleEvent);
+          setTimeout(resolve, 4000);
+        }
+      });
+
+    } else {
+      resolve();
+    }
   });
 }
 

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -303,7 +303,7 @@ function getTrackStats(peerConnection, track, options) {
   if (browser === 'firefox' || typeof options.testForFirefox  !== 'undefined') {
     return firefoxGetTrackStats(peerConnection, track);
   }
-  if (browser === 'edge') {
+  if (browser === 'edge' || typeof options.testForEdge  !== 'undefined') {
     return edgeGetTrackStats(peerConnection, track);
   }
   return Promise.reject(new Error('RTCPeerConnection#getStats() not supported'));

--- a/lib/rtcpeerconnection/edge.js
+++ b/lib/rtcpeerconnection/edge.js
@@ -54,7 +54,7 @@ inherits(EdgeRTCPeerConnection, EventTarget);
 // when sender is not part of getSenders or has been previously removed
 // bug: https://github.com/otalk/rtcpeerconnection-shim/issues/154
 EdgeRTCPeerConnection.prototype.removeTrack = function removeTrack(sender) {
-  if (!this.signalingState === 'closed') {
+  if (this.signalingState !== 'closed') {
     sender = this._peerConnection.getSenders().find(function(item) {
       return item === sender;
     });

--- a/lib/rtcpeerconnection/edge.js
+++ b/lib/rtcpeerconnection/edge.js
@@ -55,10 +55,7 @@ inherits(EdgeRTCPeerConnection, EventTarget);
 // bug: https://github.com/otalk/rtcpeerconnection-shim/issues/154
 EdgeRTCPeerConnection.prototype.removeTrack = function removeTrack(sender) {
   if (this.signalingState !== 'closed') {
-    sender = this._peerConnection.getSenders().find(function(item) {
-      return item === sender;
-    });
-    if (!sender) {
+    if (!this._peerConnection.getSenders().includes(sender)) {
       return;
     }
   }

--- a/lib/rtcpeerconnection/edge.js
+++ b/lib/rtcpeerconnection/edge.js
@@ -18,7 +18,7 @@ function EdgeRTCPeerConnection(configuration) {
 
   var peerConnection = new PeerConnection(configuration);
 
-  // Note(syerrapragada): These properties are not defined on Prototype.
+  // NOTE(syerrapragada): These properties are not defined on Prototype.
   // We need these here until upstream releases a new version.
   // see: https://github.com/otalk/rtcpeerconnection-shim/commit/755ada6cc062ca3abde12d15de7f6c8928409134
   Object.defineProperties(this, {
@@ -50,7 +50,7 @@ function EdgeRTCPeerConnection(configuration) {
 
 inherits(EdgeRTCPeerConnection, EventTarget);
 
-// Note(syerrapragada): otalk/RTCPeerConnection shim throws InvalidAccessError
+// NOTE(syerrapragada): otalk/RTCPeerConnection shim throws InvalidAccessError
 // when sender is not part of getSenders or has been previously removed
 // bug: https://github.com/otalk/rtcpeerconnection-shim/issues/154
 EdgeRTCPeerConnection.prototype.removeTrack = function removeTrack(sender) {
@@ -65,13 +65,13 @@ EdgeRTCPeerConnection.prototype.removeTrack = function removeTrack(sender) {
   this._peerConnection.removeTrack(sender);
 };
 
-// Note(syerrapragada): After close is called iceConnectionState should be 'closed'.
+// NOTE(syerrapragada): After close is called iceConnectionState should be 'closed'.
 // We need this until below PR is released
 // https://github.com/otalk/rtcpeerconnection-shim/pull/139
 EdgeRTCPeerConnection.prototype.close = function close() {
   this._peerConnection.close();
   var self = this;
-  // Note(syerrapragada): Integration test throws error without timeout
+  // NOTE(syerrapragada): Integration test throws error without timeout
   setTimeout(function() {
     self._peerConnection.iceConnectionState = 'closed';
     self._peerConnection.connectionState = 'closed';

--- a/lib/rtcpeerconnection/edge.js
+++ b/lib/rtcpeerconnection/edge.js
@@ -4,7 +4,9 @@ var EventTarget = require('../util/eventtarget');
 var inherits = require('util').inherits;
 var util = require('../util');
 
-var match = navigator.userAgent.match(/Edge\/(\d+).(\d+)$/);
+var match = typeof navigator !== 'undefined'
+  ? navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)
+  : null;
 var PeerConnection = require('rtcpeerconnection-shim')(window, match[2]);
 
 function EdgeRTCPeerConnection(configuration) {
@@ -16,6 +18,9 @@ function EdgeRTCPeerConnection(configuration) {
 
   var peerConnection = new PeerConnection(configuration);
 
+  // Note(syerrapragada): These properties are not defined on Prototype.
+  // We need these here until upstream releases a new version.
+  // see: https://github.com/otalk/rtcpeerconnection-shim/commit/755ada6cc062ca3abde12d15de7f6c8928409134
   Object.defineProperties(this, {
     _peerConnection: {
       value: peerConnection
@@ -45,23 +50,28 @@ function EdgeRTCPeerConnection(configuration) {
 
 inherits(EdgeRTCPeerConnection, EventTarget);
 
-// otalk/RTCPeerConnection shim throws InvalidAccessError
+// Note(syerrapragada): otalk/RTCPeerConnection shim throws InvalidAccessError
 // when sender is not part of getSenders or has been previously removed
+// bug: https://github.com/otalk/rtcpeerconnection-shim/issues/154
 EdgeRTCPeerConnection.prototype.removeTrack = function removeTrack(sender) {
-  if (!this._peerConnection._isClosed && (sender instanceof window.RTCRtpSender)) {
-    var s = this._peerConnection.getSenders().find(function(s) {
-      return s === sender;
+  if (!this.signalingState === 'closed') {
+    sender = this._peerConnection.getSenders().find(function(item) {
+      return item === sender;
     });
-    if (!s) {
+    if (!sender) {
       return;
     }
   }
   this._peerConnection.removeTrack(sender);
 };
 
+// Note(syerrapragada): After close is called iceConnectionState should be 'closed'.
+// We need this until below PR is released
+// https://github.com/otalk/rtcpeerconnection-shim/pull/139
 EdgeRTCPeerConnection.prototype.close = function close() {
   this._peerConnection.close();
   var self = this;
+  // Note(syerrapragada): Integration test throws error without timeout
   setTimeout(function() {
     self._peerConnection.iceConnectionState = 'closed';
     self._peerConnection.connectionState = 'closed';

--- a/lib/rtcpeerconnection/edge.js
+++ b/lib/rtcpeerconnection/edge.js
@@ -47,10 +47,10 @@ inherits(EdgeRTCPeerConnection, EventTarget);
 
 EdgeRTCPeerConnection.prototype.removeTrack = function(sender) {
   if (!this._peerConnection._isClosed && (sender instanceof window.RTCRtpSender)) {
-    var sender = this._peerConnection.getSenders().find(function(s) {
+    var s = this._peerConnection.getSenders().find(function(s) {
       return s === sender;
     });
-    if (!sender) {
+    if (!s) {
       return;
     }
   }

--- a/lib/rtcpeerconnection/edge.js
+++ b/lib/rtcpeerconnection/edge.js
@@ -47,7 +47,7 @@ inherits(EdgeRTCPeerConnection, EventTarget);
 
 // otalk/RTCPeerConnection shim throws InvalidAccessError
 // when sender is not part of getSenders or has been previously removed
-EdgeRTCPeerConnection.prototype.removeTrack = function(sender) {
+EdgeRTCPeerConnection.prototype.removeTrack = function removeTrack(sender) {
   if (!this._peerConnection._isClosed && (sender instanceof window.RTCRtpSender)) {
     var s = this._peerConnection.getSenders().find(function(s) {
       return s === sender;
@@ -59,7 +59,7 @@ EdgeRTCPeerConnection.prototype.removeTrack = function(sender) {
   this._peerConnection.removeTrack(sender);
 };
 
-EdgeRTCPeerConnection.prototype.close = function() {
+EdgeRTCPeerConnection.prototype.close = function close() {
   this._peerConnection.close();
   var self = this;
   setTimeout(function() {

--- a/lib/rtcpeerconnection/edge.js
+++ b/lib/rtcpeerconnection/edge.js
@@ -1,0 +1,76 @@
+'use strict';
+
+var EventTarget = require('../util/eventtarget');
+var inherits = require('util').inherits;
+var util = require('../util');
+
+var match = navigator.userAgent.match(/Edge\/(\d+).(\d+)$/);
+var PeerConnection = require('rtcpeerconnection-shim')(window, match[2]);
+
+function EdgeRTCPeerConnection(configuration) {
+  if (!(this instanceof EdgeRTCPeerConnection)) {
+    return new EdgeRTCPeerConnection(configuration);
+  }
+
+  EventTarget.call(this);
+
+  var peerConnection = new PeerConnection(configuration);
+
+  Object.defineProperties(this, {
+    _peerConnection: {
+      value: peerConnection
+    },
+    iceConnectionState: {
+      enumerable: true,
+      get: function() {
+        return this._peerConnection.iceConnectionState;
+      }
+    },
+    iceGatheringState: {
+      enumerable: true,
+      get: function() {
+        return this._peerConnection.iceGatheringState;
+      }
+    },
+    signalingState: {
+      enumerable: true,
+      get: function() {
+        return this._peerConnection.signalingState;
+      }
+    }
+  });
+
+  util.proxyProperties(PeerConnection.prototype, this, peerConnection);
+}
+
+inherits(EdgeRTCPeerConnection, EventTarget);
+
+EdgeRTCPeerConnection.prototype.removeTrack = function(sender) {
+  if (!this._peerConnection._isClosed && (sender instanceof window.RTCRtpSender)) {
+    var sender = this._peerConnection.getSenders().find(function(s) {
+      return s === sender;
+    });
+    if (!sender) {
+      return;
+    }
+  }
+  this._peerConnection.removeTrack(sender);
+};
+
+EdgeRTCPeerConnection.prototype.close = function() {
+  this._peerConnection.close();
+  var self = this;
+  setTimeout(function() {
+    self._peerConnection.iceConnectionState = 'closed';
+    self._peerConnection.connectionState = 'closed';
+    self.dispatchEvent(new Event('signalingstatechange'));
+    self.dispatchEvent(new Event('iceconnectionstatechange'));
+  });
+};
+
+util.delegateMethods(
+  PeerConnection.prototype,
+  EdgeRTCPeerConnection.prototype,
+  '_peerConnection');
+
+module.exports = EdgeRTCPeerConnection;

--- a/lib/rtcpeerconnection/edge.js
+++ b/lib/rtcpeerconnection/edge.js
@@ -45,6 +45,8 @@ function EdgeRTCPeerConnection(configuration) {
 
 inherits(EdgeRTCPeerConnection, EventTarget);
 
+// otalk/RTCPeerConnection shim throws InvalidAccessError
+// when sender is not part of getSenders or has been previously removed
 EdgeRTCPeerConnection.prototype.removeTrack = function(sender) {
   if (!this._peerConnection._isClosed && (sender instanceof window.RTCRtpSender)) {
     var s = this._peerConnection.getSenders().find(function(s) {

--- a/lib/rtcpeerconnection/edge.js
+++ b/lib/rtcpeerconnection/edge.js
@@ -54,10 +54,9 @@ inherits(EdgeRTCPeerConnection, EventTarget);
 // when sender is not part of getSenders or has been previously removed
 // bug: https://github.com/otalk/rtcpeerconnection-shim/issues/154
 EdgeRTCPeerConnection.prototype.removeTrack = function removeTrack(sender) {
-  if (this.signalingState !== 'closed') {
-    if (!this._peerConnection.getSenders().includes(sender)) {
+  if (this.signalingState !== 'closed'
+    && !this._peerConnection.getSenders().includes(sender)) {
       return;
-    }
   }
   this._peerConnection.removeTrack(sender);
 };

--- a/lib/rtcpeerconnection/index.js
+++ b/lib/rtcpeerconnection/index.js
@@ -12,6 +12,9 @@ switch (guessBrowser()) {
   case 'safari':
     module.exports = require('./safari');
     break;
+  case 'edge':
+    module.exports = require('./edge');
+    break;
   default:
     if (typeof RTCPeerConnection === 'undefined') {
       break;

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -106,13 +106,13 @@ function flatMap(list, mapFn) {
 
 /**
  * Guess the browser.
- * @returns {?string} browser - "chrome", "firefox", "safari", or null
+ * @returns {?string} browser - "chrome", "firefox", "safari", "edge", or null
  */
 function guessBrowser() {
   if (typeof window === 'undefined' || !window.navigator) {
     return null;
   }
-  const navigator = window && window.navigator;
+  var navigator = window.navigator;
 
   if (navigator.webkitGetUserMedia) {
     return 'chrome';

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -109,15 +109,21 @@ function flatMap(list, mapFn) {
  * @returns {?string} browser - "chrome", "firefox", "safari", or null
  */
 function guessBrowser() {
-  if (typeof webkitRTCPeerConnection !== 'undefined') {
+  if (typeof window === 'undefined' || !window.navigator) {
+    return null;
+  }
+  const navigator = window && window.navigator;
+
+  if (navigator.webkitGetUserMedia) {
     return 'chrome';
-  } else if (typeof mozRTCPeerConnection !== 'undefined') {
+  } else if (navigator.mozGetUserMedia) {
     return 'firefox';
   } else if (typeof RTCPeerConnection !== 'undefined') {
-    if (typeof navigator !== 'undefined' && navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) {
+    if (navigator.userAgent.match(/Edge\/(\d+)\./)) {
+      return 'edge';
+    } else if (navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) {
       return 'safari';
     }
-    // NOTE(mroberts): Could be Edge.
   }
   return null;
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "karma": "^1.7.0",
     "karma-browserify": "^5.1.1",
     "karma-chrome-launcher": "^2.2.0",
+    "karma-edge-launcher": "^0.4.2",
     "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "^1.3.0",
     "karma-safari-launcher": "~0.1",
@@ -49,6 +50,7 @@
     "npm-run-all": "^4.0.2",
     "release-tool": "^0.2.2",
     "rimraf": "^2.6.1",
+    "rtcpeerconnection-shim": "^1.2.13",
     "travis-multirunner": "^4.2.3",
     "watchify": "^3.9.0",
     "webrtc-adapter": "^6.1.5"

--- a/test/integration/spec/getstats.js
+++ b/test/integration/spec/getstats.js
@@ -11,7 +11,7 @@ const getUserMedia = require('../../../lib/getusermedia');
 const RTCPeerConnection = require('../../../lib/rtcpeerconnection');
 const { guessBrowser } = require('../../../lib/util');
 
-(guessBrowser() === 'safari' ? describe.skip : describe)('getStats', function() {
+(guessBrowser() === 'safari' || guessBrowser() === 'edge' ? describe.skip : describe)('getStats', function() {
   this.timeout(10000);
 
   describe('should resolve a Promise that resolves with a StandardizedStatsResponse which has', () => {

--- a/test/integration/spec/getstats.js
+++ b/test/integration/spec/getstats.js
@@ -11,6 +11,7 @@ const getUserMedia = require('../../../lib/getusermedia');
 const RTCPeerConnection = require('../../../lib/rtcpeerconnection');
 const { guessBrowser } = require('../../../lib/util');
 
+// NOTE(syerrapragada): Edge's stats report doesn't have 'candidate-pair'
 (guessBrowser() === 'safari' || guessBrowser() === 'edge' ? describe.skip : describe)('getStats', function() {
   this.timeout(10000);
 

--- a/test/integration/spec/getstats.js
+++ b/test/integration/spec/getstats.js
@@ -11,8 +11,7 @@ const getUserMedia = require('../../../lib/getusermedia');
 const RTCPeerConnection = require('../../../lib/rtcpeerconnection');
 const { guessBrowser } = require('../../../lib/util');
 
-// NOTE(syerrapragada): Edge's stats report doesn't have 'candidate-pair'
-(guessBrowser() === 'safari' || guessBrowser() === 'edge' ? describe.skip : describe)('getStats', function() {
+(guessBrowser() === 'safari' ? describe.skip : describe)('getStats', function() {
   this.timeout(10000);
 
   describe('should resolve a Promise that resolves with a StandardizedStatsResponse which has', () => {
@@ -74,7 +73,8 @@ const { guessBrowser } = require('../../../lib/util');
       stats = await getStats(pc1);
     });
 
-    it('.activeIceCandidatePair', () => {
+    // NOTE(syerrapragada): Edge's stats report doesn't have 'candidate-pair'
+    (guessBrowser() === 'edge' ? it.skip : it)('.activeIceCandidatePair', () => {
       const { activeIceCandidatePair } = stats;
       const { localCandidate, remoteCandidate } = activeIceCandidatePair;
 

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -1533,33 +1533,6 @@ s=-\r
 t=0 0\r
 a=group:BUNDLE audio\r
 a=msid-semantic: WMS\r
-m=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\r
-c=IN IP4 0.0.0.0\r
-a=rtcp:9 IN IP4 0.0.0.0\r
-a=ice-ufrag:hml5\r
-a=ice-pwd:VSJteFVvAyoewWkSfaxKgU6C\r
-a=ice-options:trickle\r
-a=fingerprint:sha-256 0D:9A:8C:E8:50:B9:0D:7F:88:50:1D:E5:0F:0F:6C:E2:24:EB:6E:D1:5F:57:EE:21:96:FD:E6:45:3C:94:12:77\r
-a=setup:actpass\r
-a=mid:audio\r
-a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r
-a=recvonly\r
-a=rtcp-mux\r
-a=rtpmap:111 opus/48000/2\r
-a=rtcp-fb:111 transport-cc\r
-a=fmtp:111 minptime=10;useinbandfec=1\r
-a=rtpmap:103 ISAC/16000\r
-a=rtpmap:104 ISAC/32000\r
-a=rtpmap:9 G722/8000\r
-a=rtpmap:0 PCMU/8000\r
-a=rtpmap:8 PCMA/8000\r
-a=rtpmap:106 CN/32000\r
-a=rtpmap:105 CN/16000\r
-a=rtpmap:13 CN/8000\r
-a=rtpmap:110 telephone-event/48000\r
-a=rtpmap:112 telephone-event/32000\r
-a=rtpmap:113 telephone-event/16000\r
-a=rtpmap:126 telephone-event/8000\r
 `;
 
   // NOTE(mroberts): https://bugs.chromium.org/p/webrtc/issues/detail?id=9540

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -1527,22 +1527,43 @@ function testSetDescription(sdpSemantics, local, signalingState, sdpType) {
 }
 
 function makeTest(options) {
+  // NOTE(mroberts): https://bugs.chromium.org/p/webrtc/issues/detail?id=9540
   var dummyOfferSdp = `v=0\r
 o=- 2018425083800689377 2 IN IP4 127.0.0.1\r
 s=-\r
 t=0 0\r
-a=group:BUNDLE audio\r
+a=group:BUNDLE ${options.sdpSemantics === 'unified-plan' ? '0' : 'audio'}\r
 a=msid-semantic: WMS\r
+m=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\r
+c=IN IP4 0.0.0.0\r
+a=rtcp:9 IN IP4 0.0.0.0\r
+a=ice-ufrag:hml5\r
+a=ice-pwd:VSJteFVvAyoewWkSfaxKgU6C\r
+a=ice-options:trickle\r
+a=fingerprint:sha-256 0F:F6:1E:6F:88:AC:BA:0F:D1:4D:D7:0C:E2:B7:8E:93:CA:75:C8:8A:A4:59:E4:66:22:3D:B7:4E:9E:E1:AB:E4\r
+a=mid:${options.sdpSemantics === 'unified-plan' ? '0' : 'audio'}\r
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r
+a=recvonly\r
+a=rtcp-mux\r
+a=rtpmap:111 opus/48000/2\r
+a=rtcp-fb:111 transport-cc\r
+a=fmtp:111 minptime=10;useinbandfec=1\r
+a=rtpmap:103 ISAC/16000\r
+a=rtpmap:104 ISAC/32000\r
+a=rtpmap:9 G722/8000\r
+a=rtpmap:0 PCMU/8000\r
+a=rtpmap:8 PCMA/8000\r
+a=rtpmap:106 CN/32000\r
+a=rtpmap:105 CN/16000\r
+a=rtpmap:13 CN/8000\r
+a=rtpmap:110 telephone-event/48000\r
+a=rtpmap:112 telephone-event/32000\r
+a=rtpmap:113 telephone-event/16000\r
+a=rtpmap:126 telephone-event/8000\r
 `;
-
-  // NOTE(mroberts): https://bugs.chromium.org/p/webrtc/issues/detail?id=9540
-  if (options.sdpSemantics === 'unified-plan') {
-    dummyOfferSdp += 'a=mid:0\r\n';
-  }
 
   var dummyAnswerSdp = dummyOfferSdp
     .replace(/a=recvonly/mg, 'a=inactive')
-    .replace(/6/mg, '7');
 
   var test = Object.assign({
     dummyAnswerSdp: dummyAnswerSdp,

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -27,7 +27,13 @@ var signalingStates = [
 
 const guess = guessBrowser();
 const isChrome = guess === 'chrome';
+const chromeVersion = isChrome && typeof navigator === 'object'
+  ? navigator.userAgent.match(/Chrom(e|ium)\/(\d+)\./)[2]
+  : null;
 const isFirefox = guess === 'firefox';
+const firefoxVersion = isFirefox && typeof navigator === 'object'
+  ? navigator.userAgent.match(/Firefox\/(\d+)\./)[1]
+  : null;
 const isSafari = guess === 'safari';
 const isEdge = guess === 'edge';
 const sdpSemanticsIsSupported = checkIfSdpSemanticsIsSupported();
@@ -653,7 +659,7 @@ function assertEqualDescriptions(actual, expected) {
 };
 
 function emptyDescription() {
-  if (isChrome) {
+  if (isChrome && chromeVersion < 70) {
     return { type: '', sdp: '' };
   }
   return null;
@@ -1531,7 +1537,10 @@ function makeTest(options) {
 o=- 2018425083800689377 2 IN IP4 127.0.0.1\r
 s=-\r
 t=0 0\r
-a=group:BUNDLE ${options.sdpSemantics === 'unified-plan' ? '0' : isFirefox ? 'sdparta_0' : 'audio'}\r
+a=group:BUNDLE ${isFirefox && firefoxVersion < 63 
+    ? 'sdparta_0' 
+    : options.sdpSemantics === 'unified-plan' || isFirefox 
+      ? '0' : 'audio'}\r
 a=msid-semantic: WMS\r
 m=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\r
 c=IN IP4 0.0.0.0\r
@@ -1539,7 +1548,10 @@ a=rtcp:9 IN IP4 0.0.0.0\r
 a=ice-ufrag:hml5\r
 a=ice-pwd:VSJteFVvAyoewWkSfaxKgU6C\r
 a=ice-options:trickle\r
-a=mid:${options.sdpSemantics === 'unified-plan' ? '0' : isFirefox ? 'sdparta_0' : 'audio'}\r
+a=mid:${isFirefox && firefoxVersion < 63
+    ? 'sdparta_0'
+    : options.sdpSemantics === 'unified-plan' || isFirefox
+      ? '0' : 'audio'}\r
 a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r
 a=recvonly\r
 a=rtcp-mux\r

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -295,7 +295,7 @@ describe(description, function() {
 
   describe('DTLS role negotiation', () => testDtlsRoleNegotiation(sdpSemantics));
 
-  (isEdge ? describe.skip : describe)('Glare', () => testGlare(sdpSemantics));
+  describe('Glare', () => testGlare(sdpSemantics));
 
   (isEdge ? describe.skip : describe)('"datachannel" event', () => {
     describe('when maxPacketLifeTime is not set', () => {
@@ -424,7 +424,7 @@ describe(description, function() {
           assert.equal(remoteVideoTrack.id, localVideoTrack.id);
         }
 
-        // TODO: Edge: This test throws InvalidState Error on setRemoteDescription/setLocalDescription
+        // TODO(syerrapragada): Edge: This test throws InvalidState Error on setRemoteDescription/setLocalDescription
         if (isEdge) {
           return;
         }
@@ -720,7 +720,7 @@ function testAddIceCandidate(sdpSemantics, signalingState) {
     'have-remote-offer': true
   }[signalingState] || false;
 
-  (signalingState === 'closed' && (isSafari || isEdge) ? context.skip : context)
+  (signalingState === 'closed' && isSafari ? context.skip : context)
   (JSON.stringify(signalingState), () => {
     var error;
     var result;
@@ -1724,7 +1724,7 @@ a=fingerprint:sha-256 0F:F6:1E:6F:88:AC:BA:0F:D1:4D:D7:0C:E2:B7:8E:93:CA:75:C8:8
       return Promise.resolve(events[0]);
     }
     return new Promise(resolve => {
-      test.peerConnection.addEventListener(event, event => resolve(event));
+      test.peerConnection.addEventListener(event, resolve);
     });
   };
 

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -29,11 +29,12 @@ const guess = guessBrowser();
 const isChrome = guess === 'chrome';
 const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
+const isEdge = guess === 'edge';
 const sdpSemanticsIsSupported = checkIfSdpSemanticsIsSupported();
 
 // NOTE(mroberts): In Chrome, we run these tests twice if `sdpSemantics` is
 // supported: once for "plan-b" and once for "unified-plan".
-const sdpSemanticsValues = isFirefox
+const sdpSemanticsValues = isFirefox || isEdge
   ? [null]  // Unified Plan
   : sdpSemanticsIsSupported
     ? ['plan-b', 'unified-plan']
@@ -84,7 +85,7 @@ describe(description, function() {
     });
   });
 
-  describe('#createDataChannel', () => {
+  (isEdge ? describe.skip : describe)('#createDataChannel', () => {
     describe('called without setting maxPacketLifeTime', () => {
       it('sets maxPacketLifeTime to null', () => {
         const pc = new RTCPeerConnection({ sdpSemantics });
@@ -102,9 +103,11 @@ describe(description, function() {
     });
 
     describe('called without setting ordered', () => {
-      const pc = new RTCPeerConnection({ sdpSemantics });
-      const dataChannel = pc.createDataChannel('foo');
-      assert.equal(dataChannel.ordered, true);
+      it('sets ordered to true', () => {
+        const pc = new RTCPeerConnection({sdpSemantics});
+        const dataChannel = pc.createDataChannel('foo');
+        assert.equal(dataChannel.ordered, true);
+      });
     });
 
     describe('called setting maxPacketLifeTime', () => {
@@ -138,6 +141,7 @@ describe(description, function() {
       it('should throw', () => {
         const pc = new RTCPeerConnection({ sdpSemantics });
         assert.throws(() => pc.createDataChannel('foo', {
+          maxPacketLifeTime: 3,
           maxPacketLifeTime: 3,
           maxRetransmits: 3
         }));
@@ -231,7 +235,7 @@ describe(description, function() {
     });
   });
 
-  (isSafari ? describe.skip : describe)('#setRemoteDescription, called twice from signaling state "stable" with the same MediaStreamTrack IDs but different SSRCs', () => {
+  (isSafari || isEdge ? describe.skip : describe)('#setRemoteDescription, called twice from signaling state "stable" with the same MediaStreamTrack IDs but different SSRCs', () => {
     let offer1;
     let offer2;
 
@@ -259,7 +263,7 @@ describe(description, function() {
     //   the right thing to do (especially when we go to Unified Plan SDP) but it's
     //   the way it's worked for a while.
     //
-    (isFirefox || isSafari
+    (isFirefox || isSafari || isEdge
       ? it
       : it.skip
     )('should create a single MediaStreamTrack for each MediaStreamTrack ID in the SDP, regardless of SSRC changes', async () => {
@@ -269,12 +273,10 @@ describe(description, function() {
       const answer1 = await pc.createAnswer();
       await pc.setLocalDescription(answer1);
       const tracksBefore = flatMap(pc.getRemoteStreams(), stream => stream.getTracks());
-
       await pc.setRemoteDescription(offer2);
       const answer2 = await pc.createAnswer();
       await pc.setLocalDescription(answer2);
       const tracksAfter = flatMap(pc.getRemoteStreams(), stream => stream.getTracks());
-
       assert.equal(tracksAfter.length, tracksBefore.length);
       tracksAfter.forEach((trackAfter, i) => {
         const trackBefore = tracksBefore[i];
@@ -285,9 +287,9 @@ describe(description, function() {
 
   describe('DTLS role negotiation', () => testDtlsRoleNegotiation(sdpSemantics));
 
-  describe('Glare', () => testGlare(sdpSemantics));
+  (isEdge ? describe.skip : describe)('Glare', () => testGlare(sdpSemantics));
 
-  describe('"datachannel" event', () => {
+  (isEdge ? describe.skip : describe)('"datachannel" event', () => {
     describe('when maxPacketLifeTime is not set', () => {
       it('sets maxPacketLifeTime to null', async () => {
         const [offerer, answerer] = createPeerConnections(sdpSemantics);
@@ -414,6 +416,10 @@ describe(description, function() {
           assert.equal(remoteVideoTrack.id, localVideoTrack.id);
         }
 
+        // TODO: Edge: This test throws InvalidState Error on setRemoteDescription/setLocalDescription
+        if (isEdge) {
+          return;
+        }
         await Promise.all([
           pc1.setRemoteDescription(answer2),
           pc2.setLocalDescription(answer2)
@@ -645,7 +651,7 @@ function assertEqualDescriptions(actual, expected) {
 };
 
 function emptyDescription() {
-  if (typeof webkitRTCPeerConnection !== 'undefined') {
+  if (isChrome) {
     return { type: '', sdp: '' };
   }
   return null;
@@ -706,7 +712,7 @@ function testAddIceCandidate(sdpSemantics, signalingState) {
     'have-remote-offer': true
   }[signalingState] || false;
 
-  (signalingState === 'closed' && isSafari ? context.skip : context)
+  (signalingState === 'closed' && (isSafari || isEdge) ? context.skip : context)
   (JSON.stringify(signalingState), () => {
     var error;
     var result;
@@ -861,7 +867,9 @@ function testClose(sdpSemantics, signalingState) {
         test.peerConnection.addEventListener('signalingstatechange', onSigalingStateChanged);
         var closePromise = test.close();
         test.peerConnection.removeEventListener('signalingstatechange', onSigalingStateChanged);
-        return closePromise.then(results => result = results[0]);
+        return closePromise.then(results => {
+          result = results[0]
+        });
       });
     });
 
@@ -876,7 +884,7 @@ function testClose(sdpSemantics, signalingState) {
     };
 
     Object.keys(expected).forEach(property => {
-      (property === 'iceGatheringState' && isChrome
+      (property === 'iceGatheringState' && (isChrome || isEdge)
         ? it.skip
         : it
       )('should set .' + property + ' to ' + JSON.stringify(expected[property]), () => {
@@ -1509,7 +1517,8 @@ function testSetDescription(sdpSemantics, local, signalingState, sdpType) {
           return test.waitFor('signalingstatechange');
         });
       } else {
-        it('should not raise a signalingstatechange event', () => {
+        // Skip test until https://github.com/otalk/rtcpeerconnection-shim/issues/142 is released
+        (isEdge ? it.skip: it)('should not raise a signalingstatechange event', () => {
           return test.eventIsNotRaised('signalingstatechange');
         });
       }
@@ -1519,13 +1528,38 @@ function testSetDescription(sdpSemantics, local, signalingState, sdpType) {
 
 function makeTest(options) {
   var dummyOfferSdp = `v=0\r
-o=- 6666666666666666666 6 IN IP4 127.0.0.1\r
+o=- 2018425083800689377 2 IN IP4 127.0.0.1\r
 s=-\r
 t=0 0\r
+a=group:BUNDLE audio\r
 a=msid-semantic: WMS\r
-m=audio 0 UDP/TLS/RTP/SAVPF 111\r
+m=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\r
+c=IN IP4 0.0.0.0\r
+a=rtcp:9 IN IP4 0.0.0.0\r
+a=ice-ufrag:hml5\r
+a=ice-pwd:VSJteFVvAyoewWkSfaxKgU6C\r
+a=ice-options:trickle\r
+a=fingerprint:sha-256 0D:9A:8C:E8:50:B9:0D:7F:88:50:1D:E5:0F:0F:6C:E2:24:EB:6E:D1:5F:57:EE:21:96:FD:E6:45:3C:94:12:77\r
+a=setup:actpass\r
+a=mid:audio\r
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r
 a=recvonly\r
-c=IN IP4 127.0.0.1\r
+a=rtcp-mux\r
+a=rtpmap:111 opus/48000/2\r
+a=rtcp-fb:111 transport-cc\r
+a=fmtp:111 minptime=10;useinbandfec=1\r
+a=rtpmap:103 ISAC/16000\r
+a=rtpmap:104 ISAC/32000\r
+a=rtpmap:9 G722/8000\r
+a=rtpmap:0 PCMU/8000\r
+a=rtpmap:8 PCMA/8000\r
+a=rtpmap:106 CN/32000\r
+a=rtpmap:105 CN/16000\r
+a=rtpmap:13 CN/8000\r
+a=rtpmap:110 telephone-event/48000\r
+a=rtpmap:112 telephone-event/32000\r
+a=rtpmap:113 telephone-event/16000\r
+a=rtpmap:126 telephone-event/8000\r
 `;
 
   // NOTE(mroberts): https://bugs.chromium.org/p/webrtc/issues/detail?id=9540
@@ -1664,7 +1698,9 @@ c=IN IP4 127.0.0.1\r
       test.events.set(event, []);
     }
     var events = test.events.get(event);
-    test.peerConnection.addEventListener(event, event => events.push(event));
+    test.peerConnection.addEventListener(event, event => {
+      events.push(event)
+    });
   });
 
   test.resetEvent = function resetEvent(event) {
@@ -1681,7 +1717,9 @@ c=IN IP4 127.0.0.1\r
       return Promise.resolve(events[0]);
     }
     return new Promise(resolve => {
-      test.peerConnection.addEventListener(event, resolve);
+      test.peerConnection.addEventListener(event, event =>  {
+        resolve(event);
+      });
     });
   };
 


### PR DESCRIPTION
I fixed most of the integration tests on Edge. @markandrus @manjeshbhargav There are still couple of integration test failures that need fix.
 1. `#TrackEvent`  failing with InvalidState Error
 2. All `rollback` sdp type tests.