### PR TITLE
Firefox: Calling addTransceiver should update getSenders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+2.1.3 (August 8, 2018)
+======================
+
+Bug Fixes
+---------
+
+- Fixed a bug in Firefox where calling `addTransceiver` wouldn't update the
+  result of `getSenders`.
+
 2.1.2 (August 7, 2018)
 ======================
 

--- a/lib/rtcpeerconnection/firefox.js
+++ b/lib/rtcpeerconnection/firefox.js
@@ -153,6 +153,19 @@ FirefoxRTCPeerConnection.prototype.addTrack = function addTrack() {
   return sender;
 };
 
+if (PeerConnection.prototype.addTransceiver) {
+  FirefoxRTCPeerConnection.prototype.addTransceiver = function addTransceiver() {
+    var transceiver = this._peerConnection.addTransceiver.apply(this._peerConnection, arguments);
+    var sender = transceiver.sender;
+    var track = sender.track;
+    if (track && needsWorkaroundForBug1480277) {
+      sender.replaceTrack(track);
+    }
+    this._senders.set(track, sender);
+    return transceiver;
+  };
+}
+
 // NOTE(mmalavalli): RTCPeerConnection#removeTrack() has a bug in the
 // Firefox <--> Chrome interop case, which is mentioned below. So we disable
 // its delegation for now. Also, we maintain only one RTCRtpSender per

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -74,6 +74,8 @@ describe(description, function() {
 
   describe('#addTrack', () => testAddTrack(sdpSemantics));
 
+  (isFirefox && RTCPeerConnection.prototype.addTransceiver ? describe.only : describe.skip)('#addTransceiver', () => testAddTransceiver());
+
   describe('#removeTrack', () => testRemoveTrack(sdpSemantics));
 
   describe('#createAnswer, called from signaling state', () => {
@@ -939,6 +941,27 @@ function testAddTrack(sdpSemantics) {
     const addedTracks = getTracks(test.peerConnection);
     assert.deepEqual(addedTracks, stream.getTracks());
     assert.deepEqual(senders.map(sender => sender.track), stream.getTracks());
+  });
+}
+
+function testAddTransceiver() {
+  let test;
+  let track;
+
+  before(async () => {
+    const stream = await makeStream();
+    [track] = stream.getTracks();
+    test = await makeTest({});
+  });
+
+  it('should add each of the MediaStreamTracks to the RTCPeerConnection', () => {
+    const transceiver = test.peerConnection.addTransceiver(track);
+    assert.equal(transceiver.sender.track, track);
+    assert.equal(test.peerConnection.getTransceivers().length, 1);
+    assert(test.peerConnection.getTransceivers().includes(transceiver));
+    const senders = test.peerConnection.getSenders();
+    assert.equal(senders.length, 1);
+    assert(senders.includes(transceiver.sender));
   });
 }
 


### PR DESCRIPTION
@manjeshbhargav I'm exploring some changes on the 1.x branch of twilio-video.js. They're still unreleased, but the most recent work is happening here: https://github.com/twilio/twilio-video.js/pull/406 I want to use `addTransceiver`, but the 2.x version of this shim needs the following change to support it. 3.x version of this shim does not.