### PR TITLE
Fix EventEmitter memory leak in Edge's getstats implementation

### DIFF
--- a/lib/edgestats.js
+++ b/lib/edgestats.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var util = require('./util');
-var deferreds = new WeakMap();
+var iceCompletionDeferreds = new WeakMap();
 
 /**
  * Get the standardized statistics for a particular MediaStreamTrack in Edge.
@@ -9,7 +9,7 @@ var deferreds = new WeakMap();
  * @param {MediaStreamTrack} track
  * @returns {Promise.<RTCStatsReport>}
  */
-function edgeGetTrackStats(peerConnection, track) {
+function edgeGetStats(peerConnection, track) {
   // NOTE(syerrapragada): getStats Promise is rejected if ice state is not completed
   // https://msdn.microsoft.com/en-us/library/mt599588(v=vs.85).aspx
   return waitForEdgeIceCompletion(peerConnection).then(function() {
@@ -27,14 +27,15 @@ function waitForEdgeIceCompletion(peerConnection) {
   if (peerConnection.iceConnectionState === 'new'
     || peerConnection.iceConnectionState === 'checking'
     || peerConnection.iceConnectionState === 'connected') {
-    if (deferreds.has(peerConnection)) {
-      return deferreds.get(peerConnection).promise;
+    if (iceCompletionDeferreds.has(peerConnection)) {
+      return iceCompletionDeferreds.get(peerConnection).promise;
     }
     var deferred = util.defer();
-    deferreds.set(peerConnection, deferred);
+    iceCompletionDeferreds.set(peerConnection, deferred);
     peerConnection.addEventListener('iceconnectionstatechange', function onIceConnectionStateChanged() {
       if (peerConnection.iceConnectionState === 'completed' || peerConnection.iceConnectionState === 'failed') {
         peerConnection.removeEventListener('iceconnectionstatechange', onIceConnectionStateChanged);
+        iceCompletionDeferreds.delete(peerConnection);
         // NOTE(syerrapragada): Without a 250ms delay getStats method returns a promise that is rejected
         setTimeout(deferred.resolve, 250);
       }
@@ -44,4 +45,4 @@ function waitForEdgeIceCompletion(peerConnection) {
   return Promise.resolve();
 }
 
-exports.edgeGetTrackStats = edgeGetTrackStats;
+module.exports = edgeGetStats;

--- a/lib/edgestats.js
+++ b/lib/edgestats.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var util = require('./util');
+var deferreds = new WeakMap();
+
+/**
+ * Get the standardized statistics for a particular MediaStreamTrack in Edge.
+ * @param {RTCPeerConnection} peerConnection
+ * @param {MediaStreamTrack} track
+ * @returns {Promise.<RTCStatsReport>}
+ */
+function edgeGetTrackStats(peerConnection, track) {
+  // NOTE(syerrapragada): getStats Promise is rejected if ice state is not completed
+  // https://msdn.microsoft.com/en-us/library/mt599588(v=vs.85).aspx
+  return waitForEdgeIceCompletion(peerConnection).then(function() {
+    return peerConnection.getStats(track);
+  });
+}
+
+/**
+ * Waits for ice connection state is completed or failed.
+ *
+ * @param {RTCPeerConnection} peerConnection
+ * @returns {Promise<void>}
+ */
+function waitForEdgeIceCompletion(peerConnection) {
+  if (peerConnection.iceConnectionState === 'new'
+    || peerConnection.iceConnectionState === 'checking'
+    || peerConnection.iceConnectionState === 'connected') {
+    if (deferreds.has(peerConnection)) {
+      return deferreds.get(peerConnection).promise;
+    }
+    var deferred = util.defer();
+    deferreds.set(peerConnection, deferred);
+    peerConnection.addEventListener('iceconnectionstatechange', function onIceConnectionStateChanged() {
+      if (peerConnection.iceConnectionState === 'completed' || peerConnection.iceConnectionState === 'failed') {
+        peerConnection.removeEventListener('iceconnectionstatechange', onIceConnectionStateChanged);
+        // NOTE(syerrapragada): Without a 250ms delay getStats method returns a promise that is rejected
+        setTimeout(deferred.resolve, 250);
+      }
+    });
+    return deferred.promise;
+  }
+  return Promise.resolve();
+}
+
+exports.edgeGetTrackStats = edgeGetTrackStats;

--- a/lib/edgestats.js
+++ b/lib/edgestats.js
@@ -35,9 +35,11 @@ function waitForEdgeIceCompletion(peerConnection) {
     peerConnection.addEventListener('iceconnectionstatechange', function onIceConnectionStateChanged() {
       if (peerConnection.iceConnectionState === 'completed' || peerConnection.iceConnectionState === 'failed') {
         peerConnection.removeEventListener('iceconnectionstatechange', onIceConnectionStateChanged);
-        iceCompletionDeferreds.delete(peerConnection);
         // NOTE(syerrapragada): Without a 250ms delay getStats method returns a promise that is rejected
-        setTimeout(deferred.resolve, 250);
+        setTimeout(function() {
+          iceCompletionDeferreds.delete(peerConnection);
+          deferred.resolve();
+        }, 250);
       }
     });
     return deferred.promise;

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var edgeGetStats = require('./edgestats').edgeGetStats;
+var edgeGetStats = require('./edgestats');
 var flatMap = require('./util').flatMap;
 var guessBrowser = require('./util').guessBrowser;
 

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var edgeGetTrackStats = require('./edgestats').edgeGetTrackStats;
 var flatMap = require('./util').flatMap;
 var guessBrowser = require('./util').guessBrowser;
 
@@ -301,7 +302,7 @@ function getTrackStats(peerConnection, track, options) {
     return firefoxGetTrackStats(peerConnection, track);
   }
   if (browser === 'edge' || options.testForEdge) {
-    return edgeGetTrackStats(peerConnection, track);
+    return edgeGetTrackStats(peerConnection, track).then(standardizeEdgeAndFirefoxStats);
   }
   return Promise.reject(new Error('RTCPeerConnection#getStats() not supported'));
 }
@@ -318,43 +319,6 @@ function chromeGetTrackStats(peerConnection, track) {
       resolve(standardizeChromeStats(response, track));
     }, null, reject);
   });
-}
-
-/**
- * Get the standardized statistics for a particular MediaStreamTrack in Edge.
- * @param {RTCPeerConnection} peerConnection
- * @param {MediaStreamTrack} track
- * @returns {Promise.<StandardizedTrackStatsReport>}
- */
-function edgeGetTrackStats(peerConnection, track) {
-  // NOTE(syerrapragada): getStats Promise is rejected if ice state is not completed
-  // https://msdn.microsoft.com/en-us/library/mt599588(v=vs.85).aspx
-  return waitForEdgeIceCompletion(peerConnection).then(function() {
-    return peerConnection.getStats(track);
-  }).then(standardizeEdgeAndFirefoxStats);
-}
-
-/**
- * Waits for ice connection state is completed or failed.
- *
- * @param {RTCPeerConnection} peerConnection
- * @returns {Promise<void>}
- */
-function waitForEdgeIceCompletion(peerConnection) {
-  if (peerConnection.iceConnectionState === 'new'
-    || peerConnection.iceConnectionState === 'checking'
-    || peerConnection.iceConnectionState === 'connected') {
-    return new Promise(function(resolve) {
-      peerConnection.addEventListener('iceconnectionstatechange', function onIceConnectionStateChanged() {
-        if (peerConnection.iceConnectionState === 'completed' || peerConnection.iceConnectionState === 'failed') {
-          peerConnection.removeEventListener('iceconnectionstatechange', onIceConnectionStateChanged);
-          // NOTE(syerrapragada): Without a 250ms delay getStats method returns a promise that is rejected
-          setTimeout(resolve, 250);
-        }
-      });
-    });
-  }
-  return Promise.resolve();
 }
 
 /**

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var edgeGetTrackStats = require('./edgestats').edgeGetTrackStats;
+var edgeGetStats = require('./edgestats').edgeGetStats;
 var flatMap = require('./util').flatMap;
 var guessBrowser = require('./util').guessBrowser;
 
@@ -302,7 +302,7 @@ function getTrackStats(peerConnection, track, options) {
     return firefoxGetTrackStats(peerConnection, track);
   }
   if (browser === 'edge' || options.testForEdge) {
-    return edgeGetTrackStats(peerConnection, track).then(standardizeEdgeAndFirefoxStats);
+    return edgeGetStats(peerConnection, track).then(standardizeEdgeAndFirefoxStats);
   }
   return Promise.reject(new Error('RTCPeerConnection#getStats() not supported'));
 }


### PR DESCRIPTION
@markandrus @manjeshbhargav 
Edge implementation of stats was logging following warning/error:

`possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit`

This PR is an attempt to fix the leak. Please review.