### PR TITLE
JSDK-2235 Consuming spec-compliant RTCIceCandidateStats from Firefox 65 onwards.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 New Features
 ------------
 
+- `getStats` on Firefox will now consume the spec-compliant `RTCIceCandidateStats`
+  available in [versions 65 and above](https://www.fxsitecompat.com/en-CA/docs/2018/rtcicecandidatestats-has-been-updated-to-the-latest-spec/). (JSDK-2235)
+
 - `getStats` is now supported on Safari 12.1 and above. It is not supported
   on Safari 12.0 and below due to this [Safari bug](https://bugs.webkit.org/show_bug.cgi?id=192601).
 

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -191,10 +191,10 @@ function standardizeFirefoxActiveIceCandidatePairStats(stats) {
 
   var standardizedCandidateStatsKeys = [
     { key: 'candidateType', type: 'string' },
-    { key: 'ip', ffKey: 'ipAddress', type: 'string' },
-    { key: 'port', ffKey: 'portNumber', type: 'number' },
+    { key: 'ip', ffKeys: ['address', 'ipAddress'], type: 'string' },
+    { key: 'port', ffKeys: ['portNumber'], type: 'number' },
     { key: 'priority', type: 'number' },
-    { key: 'protocol', ffKey: 'transport', type: 'string' },
+    { key: 'protocol', ffKeys: ['transport'], type: 'string' },
     { key: 'url', type: 'string' }
   ];
 
@@ -212,7 +212,9 @@ function standardizeFirefoxActiveIceCandidatePairStats(stats) {
 
   var standatdizedLocalCandidateStatsReport = activeLocalCandidateStats
     ? standardizedLocalCandidateStatsKeys.reduce(function(report, keyInfo) {
-      var key = keyInfo.ffKey || keyInfo.key;
+      var key = keyInfo.ffKeys && keyInfo.ffKeys.find(function(key) {
+        return key in activeLocalCandidateStats;
+      }) || keyInfo.key;
       report[keyInfo.key] = typeof activeLocalCandidateStats[key] === keyInfo.type
         ? key === 'candidateType'
           ? candidateTypes[activeLocalCandidateStats[key]] || activeLocalCandidateStats[key]
@@ -224,7 +226,9 @@ function standardizeFirefoxActiveIceCandidatePairStats(stats) {
 
   var standardizedRemoteCandidateStatsReport = activeRemoteCandidateStats
     ? standardizedCandidateStatsKeys.reduce(function(report, keyInfo) {
-      var key = keyInfo.ffKey || keyInfo.key;
+      var key = keyInfo.ffKeys && keyInfo.ffKeys.find(function(key) {
+        return key in activeRemoteCandidateStats;
+      }) || keyInfo.key;
       report[keyInfo.key] = typeof activeRemoteCandidateStats[key] === keyInfo.type
         ? key === 'candidateType'
           ? candidateTypes[activeRemoteCandidateStats[key]] || activeRemoteCandidateStats[key]

--- a/test/integration/spec/getstats.js
+++ b/test/integration/spec/getstats.js
@@ -111,7 +111,8 @@ sdpSemanticsValues.forEach(sdpSemantics => {
           {key: 'url', type: 'string'}
         ].forEach(({key, type}) => {
           [localCandidate, remoteCandidate].forEach((candidate, i) => {
-            if ([localCandidateStatsNullProps, remoteCandidateStatsNullProps][i][guessBrowser()].has(key)) {
+            const firefoxVersion = isFirefox && navigator.userAgent.match(/Firefox\/(\d+)\./)[1];
+            if ([localCandidateStatsNullProps, remoteCandidateStatsNullProps][i][guessBrowser()](firefoxVersion).has(key)) {
               assert.equal(candidate[key], null);
               return;
             }
@@ -140,7 +141,8 @@ sdpSemanticsValues.forEach(sdpSemantics => {
           {key: 'deleted', type: 'boolean'},
           {key: 'relayProtocol', type: 'string'}
         ].forEach(({key, type}) => {
-          if (localCandidateStatsNullProps[guessBrowser()].has(key)) {
+          const firefoxVersion = isFirefox && navigator.userAgent.match(/Firefox\/(\d+)\./)[1];
+          if (localCandidateStatsNullProps[guessBrowser()](firefoxVersion).has(key)) {
             assert.equal(localCandidate[key], null);
             return;
           }

--- a/test/lib/util.js
+++ b/test/lib/util.js
@@ -275,15 +275,15 @@ const activeIceCandidatePairStatsNullProps = {
 };
 
 const localCandidateStatsNullProps = {
-  chrome: new Set(['relayProtocol', 'url']),
-  firefox: new Set(['priority', 'relayProtocol', 'url']),
-  safari: new Set(['ip', 'relayProtocol', 'url'])
+  chrome: () => new Set(['relayProtocol', 'url']),
+  firefox: version => version < 65 ? new Set(['priority', 'relayProtocol', 'url']) : new Set(['relayProtocol', 'url']),
+  safari: () => new Set(['ip', 'relayProtocol', 'url'])
 };
 
 const remoteCandidateStatsNullProps = {
-  chrome: new Set(['url']),
-  firefox: new Set(['priority', 'url']),
-  safari: new Set(['ip', 'url'])
+  chrome: () => new Set(['url']),
+  firefox: version => version < 65 ? new Set(['priority', 'url']) : new Set(['url']),
+  safari: () => new Set(['ip', 'url'])
 };
 
 exports.activeIceCandidatePairStatsNullProps = activeIceCandidatePairStatsNullProps;


### PR DESCRIPTION
@syerrapragada 

This fixes the failing `getStats` integration tests for Firefox 65.