### PR TITLE
JSDK-2219

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+3.2.1 (in progress)
+===================
+
+New Features
+------------
+
+- Worked around Firefox [Bug 1491957](https://bugzilla.mozilla.org/show_bug.cgi?id=1491957).
+
 3.2.0 (January 7, 2019)
 =======================
 

--- a/README.md
+++ b/README.md
@@ -84,12 +84,13 @@ browsers.
 * For new offers, adds support for calling `setLocalDescription` and `setRemoteDescription` in
   `have-local-offer` and `have-remote-offer` signaling states respectively.
 * Adds support for calling `createOffer` in signaling state `have-local-offer`.
-* The above features are implemented using rollback to work around [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1072388).
+* The above features are implemented using simulated rollback to work around [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1072388).
 * Provides a workaround for [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1240897), where the browser may
   change the previously negotiated DTLS role in an answer, which breaks Chrome.
 * Provides a workaround for [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1363815),
   where the browser throws when `RTCPeerConnection.prototype.peerIdentity` is accessed.
 * Works around Firefox [Bug 1480277](https://bugzilla.mozilla.org/show_bug.cgi?id=1480277).
+* Works around Firefox [Bug 1491957](https://bugzilla.mozilla.org/show_bug.cgi?id=1491957).
 
 #### Safari
 * Adds rollback support, according to the workaround specified [here](https://bugs.chromium.org/p/webrtc/issues/detail?id=5738#c3).

--- a/lib/rtcpeerconnection/firefox.js
+++ b/lib/rtcpeerconnection/firefox.js
@@ -4,6 +4,7 @@
 var EventTarget = require('../util/eventtarget');
 var FirefoxRTCSessionDescription = require('../rtcsessiondescription/firefox');
 var inherits = require('util').inherits;
+var Latch = require('../util/latch');
 var updateTracksToSSRCs = require('../util/sdp').updateUnifiedPlanTrackIdsToSSRCs;
 var util = require('../util');
 
@@ -28,8 +29,8 @@ var needsWorkaroundForBug1480277 = typeof navigator === 'object'
 //
 //   2. The ability to call createOffer in signalingState "have-local-offer".
 //
-// Both of these are implemented using rollbacks to workaround the following
-// bug:
+// Both of these are implemented by simulating rollback behavior to workaround
+// the following bug:
 //
 //   https://bugzilla.mozilla.org/show_bug.cgi?id=1072388
 //
@@ -37,6 +38,17 @@ var needsWorkaroundForBug1480277 = typeof navigator === 'object'
 // previously-negotiated DTLS role in an answer, which breaks Chrome:
 //
 //     https://bugzilla.mozilla.org/show_bug.cgi?id=1240897
+//
+// NOTE(mmalavalli): We also provide a workaround for this bug:
+//
+//   https://bugzilla.mozilla.org/show_bug.cgi?id=1491957
+//
+// This workaround is implemented by:
+//
+//   1. Simulating rollback by caching the most recent local offer.
+//
+//   2. Returning the cached offer if createOffer() is called before the
+//      negotiation is complete.
 //
 function FirefoxRTCPeerConnection(configuration) {
   if (!(this instanceof FirefoxRTCPeerConnection)) {
@@ -62,9 +74,16 @@ function FirefoxRTCPeerConnection(configuration) {
     _peerConnection: {
       value: peerConnection
     },
-    _rollingBack: {
-      value: false,
+    _pendingLocalOffer: {
+      value: null,
       writable: true
+    },
+    _pendingRemoteOffer: {
+      value: null,
+      writable: true
+    },
+    _signalingStateLatch: {
+      value: new Latch()
     },
     _tracksToSSRCs: {
       value: new Map()
@@ -78,13 +97,30 @@ function FirefoxRTCPeerConnection(configuration) {
     localDescription: {
       enumerable: true,
       get: function() {
-        return overwriteWithInitiallyNegotiatedDtlsRole(this._peerConnection.localDescription, this._initiallyNegotiatedDtlsRole);
+        return overwriteWithInitiallyNegotiatedDtlsRole(
+          this._pendingLocalOffer || peerConnection.localDescription,
+          this._initiallyNegotiatedDtlsRole);
+      }
+    },
+    remoteDescription: {
+      enumerable: true,
+      get: function() {
+        return this._pendingRemoteOffer || peerConnection.remoteDescription;
       }
     },
     signalingState: {
       enumerable: true,
       get: function() {
-        return this._isClosed ? 'closed' : this._peerConnection.signalingState;
+        if (this._isClosed) {
+          return 'closed';
+        }
+        if (this._pendingLocalOffer) {
+          return 'have-local-offer';
+        }
+        if (this._pendingRemoteOffer) {
+          return 'have-remote-offer';
+        }
+        return peerConnection.signalingState;
       }
     }
   });
@@ -93,7 +129,10 @@ function FirefoxRTCPeerConnection(configuration) {
   var previousSignalingState;
 
   peerConnection.addEventListener('signalingstatechange', function onsignalingstatechange() {
-    if (!self._rollingBack && self.signalingState !== previousSignalingState) {
+    if (self._pendingLocalOffer || self._pendingRemoteOffer) {
+      return;
+    }
+    if (self.signalingState !== previousSignalingState) {
       previousSignalingState = self.signalingState;
 
       // NOTE(mmalavalli): In Firefox, 'signalingstatechange' event is
@@ -135,45 +174,80 @@ if (needsWorkaroundForBug1480277) {
   };
 }
 
+FirefoxRTCPeerConnection.prototype.addIceCandidate = function addIceCandidate(candidate) {
+  var args = [].slice.call(arguments);
+  var promise;
+  var self = this;
+
+  if (this.signalingState === 'have-remote-offer') {
+    // NOTE(mmalavalli): Because the FirefoxRTCPeerConnection simulates the
+    // "have-remote-offer" signalingState, we only want to invoke the true
+    // addIceCandidates method when the remote description has been applied.
+    promise = this._signalingStateLatch.when('low').then(function signalingStatesResolved() {
+      return self._peerConnection.addIceCandidate(candidate);
+    });
+  } else {
+    promise = this._peerConnection.addIceCandidate(candidate);
+  }
+
+  return args.length > 1
+    ? util.legacyPromise(promise, args[1], args[2])
+    : promise;
+};
+
+
 FirefoxRTCPeerConnection.prototype.createAnswer = function createAnswer() {
   var args = [].slice.call(arguments);
   var promise;
   var self = this;
 
-  promise = this._peerConnection.createAnswer().then(function createAnswerSucceeded(answer) {
-    saveInitiallyNegotiatedDtlsRole(self, answer);
-    return overwriteWithInitiallyNegotiatedDtlsRole(answer, self._initiallyNegotiatedDtlsRole);
-  });
+  if (this._pendingRemoteOffer) {
+    promise = this._peerConnection.setRemoteDescription(this._pendingRemoteOffer).then(function setRemoteDescriptionSucceeded() {
+      // NOTE(mmalavalli): The signalingStates between the FirefoxRTCPeerConnection
+      // and the underlying RTCPeerConnection implementation have converged. We
+      // can unblock any pending calls to addIceCandidate now.
+      self._signalingStateLatch.lower();
+      return self._peerConnection.createAnswer();
+    }).then(function createAnswerSucceeded(answer) {
+      self._pendingRemoteOffer = null;
+      saveInitiallyNegotiatedDtlsRole(self, answer);
+      return overwriteWithInitiallyNegotiatedDtlsRole(answer, self._initiallyNegotiatedDtlsRole);
+    }, function setRemoteDescriptionOrCreateAnswerFailed(error) {
+      self._pendingRemoteOffer = null;
+      throw error;
+    });
+  } else {
+    promise = this._peerConnection.createAnswer().then(function createAnswerSucceeded(answer) {
+      saveInitiallyNegotiatedDtlsRole(self, answer);
+      return overwriteWithInitiallyNegotiatedDtlsRole(answer, self._initiallyNegotiatedDtlsRole);
+    });
+  }
 
   return typeof args[0] === 'function'
     ? util.legacyPromise(promise, args[0], args[1])
     : promise;
 };
 
-// NOTE(mroberts): The WebRTC spec allows you to call createOffer from any
+// NOTE(mmalavalli): The WebRTC spec allows you to call createOffer from any
 // signalingState other than "closed"; however, Firefox has not yet implemented
 // this (https://bugzilla.mozilla.org/show_bug.cgi?id=1072388). We workaround
-// this by rolling back if we are in state "have-local-offer" or
-// "have-remote-offer". This is acceptable for our use case because we will
-// apply the newly-created offer almost immediately; however, this may be
-// unacceptable for other use cases.
+// this by only calling createOffer() on the underlying RTCPeerConnection if the
+// signalingState is "stable". Otherwise, we return the pending local offer.
+// This is acceptable for our use case because we will apply the newly-created
+// offer almost immediately; however, this may be unacceptable for other use cases.
 FirefoxRTCPeerConnection.prototype.createOffer = function createOffer() {
   var args = [].slice.call(arguments);
   var options = (args.length > 1 ? args[2] : args[0]) || {};
-  var promise;
   var self = this;
 
-  if (this.signalingState === 'have-local-offer' ||
-      this.signalingState === 'have-remote-offer') {
-    var local = this.signalingState === 'have-local-offer';
-    promise = rollback(this, local, function rollbackSucceeded() {
-      return self.createOffer(options);
-    });
-  } else {
-    promise = self._peerConnection.createOffer(options);
-  }
-
-  promise = promise.then(function(offer) {
+  // NOTE(mmalavalli): Because of a bug where calling createOffer() twice
+  // changes the MIDs of RTCRtpTransceivers that have not been negotiated yet,
+  // we return the cached pending local offer instead of calling the underlying
+  // RTCPeerConnection's createOffer().
+  //
+  //   Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1491957
+  //
+  var promise = this._pendingLocalOffer ? Promise.resolve(this._pendingLocalOffer) : this._peerConnection.createOffer(options).then(function(offer) {
     return new FirefoxRTCSessionDescription({
       type: offer.type,
       sdp: updateTracksToSSRCs(self._tracksToSSRCs, offer.sdp)
@@ -185,34 +259,19 @@ FirefoxRTCPeerConnection.prototype.createOffer = function createOffer() {
     : promise;
 };
 
-// NOTE(mroberts): While Firefox will reject the Promise returned by
-// setLocalDescription when called from signalingState "have-local-offer" with
-// an answer, it still updates the .localDescription property. We workaround
-// this by explicitly handling this case.
 FirefoxRTCPeerConnection.prototype.setLocalDescription = function setLocalDescription() {
   var args = [].slice.call(arguments);
   var description = args[0];
-  var promise;
-
-  if (description && description.type === 'answer' && this.signalingState === 'have-local-offer') {
-    promise = Promise.reject(new Error('Cannot set local answer in state have-local-offer'));
-  }
-
-  if (promise) {
-    return args.length > 1
-      ? util.legacyPromise(promise, args[1], args[2])
-      : promise;
-  }
-
-  return this._peerConnection.setLocalDescription.apply(this._peerConnection, args);
+  var promise = setDescription(this, true, description);
+  return args.length > 1
+    ? util.legacyPromise(promise, args[1], args[2])
+    : promise;
 };
 
-// NOTE(mroberts): The WebRTC spec allows you to call setRemoteDescription with
+// NOTE(mmalavalli): The WebRTC spec allows you to call setRemoteDescription with
 // an offer multiple times in signalingState "have-remote-offer"; however,
 // Firefox has not yet implemented this (https://bugzilla.mozilla.org/show_bug.cgi?id=1072388).
-// We workaround this by rolling back if we are in state "have-remote-offer".
-// This is acceptable for our use case; however, this may be unacceptable for
-// other use cases.
+// We workaround this by simulating rollback.
 //
 // While Firefox will reject the Promise returned by setRemoteDescription when
 // called from signalingState "have-remote-offer" with an answer, it sill
@@ -221,24 +280,8 @@ FirefoxRTCPeerConnection.prototype.setLocalDescription = function setLocalDescri
 FirefoxRTCPeerConnection.prototype.setRemoteDescription = function setRemoteDescription() {
   var args = [].slice.call(arguments);
   var description = args[0];
-  var promise;
   var self = this;
-
-  if (description && this.signalingState === 'have-remote-offer') {
-    if (description.type === 'answer') {
-      promise = Promise.reject(new Error('Cannot set remote answer in state have-remote-offer'));
-    } else if (description.type === 'offer') {
-      promise = rollback(this, false, function rollbackSucceeded() {
-        return self._peerConnection.setRemoteDescription(description);
-      });
-    }
-  }
-
-  if (!promise) {
-    promise = this._peerConnection.setRemoteDescription(description);
-  }
-
-  promise = promise.then(function setRemoteDescriptionSucceeded() {
+  var promise = setDescription(this, false, description).then(function setRemoteDescriptionSucceeded() {
     saveInitiallyNegotiatedDtlsRole(self, description, true);
   });
 
@@ -253,6 +296,8 @@ FirefoxRTCPeerConnection.prototype.setRemoteDescription = function setRemoteDesc
 FirefoxRTCPeerConnection.prototype.close = function close() {
   if (this.signalingState !== 'closed') {
     this._isClosed = true;
+    this._pendingLocalOffer = null;
+    this._pendingRemoteOffer = null;
     this._peerConnection.close();
   }
 };
@@ -262,17 +307,89 @@ util.delegateMethods(
   FirefoxRTCPeerConnection.prototype,
   '_peerConnection');
 
-function rollback(peerConnection, local, onceRolledBack) {
+// NOTE(mmalavalli): In order to simulate Firefox's native rollback support, we
+// "fake" setting the local or remote description and instead buffer it. If we
+// receive or create an answer, then we will actually apply the description.
+// Until we receive or create an answer, we will be able to "rollback" by simply
+// discarding the buffer description.
+function setDescription(peerConnection, local, description) {
+  function setPendingLocalOffer(offer) {
+    if (local) {
+      peerConnection._pendingLocalOffer = offer;
+    } else {
+      peerConnection._pendingRemoteOffer = offer;
+    }
+  }
+
+  function clearPendingLocalOffer() {
+    if (local) {
+      peerConnection._pendingLocalOffer = null;
+    } else {
+      peerConnection._pendingRemoteOffer = null;
+    }
+  }
+
+  var pendingLocalOffer = local ? peerConnection._pendingLocalOffer : peerConnection._pendingRemoteOffer;
+  var pendingRemoteOffer = local ? peerConnection._pendingRemoteOffer : peerConnection._pendingLocalOffer;
+  var intermediateState = local ? 'have-local-offer' : 'have-remote-offer';
   var setLocalDescription = local ? 'setLocalDescription' : 'setRemoteDescription';
-  peerConnection._rollingBack = true;
-  return peerConnection._peerConnection[setLocalDescription](new FirefoxRTCSessionDescription({
-    type: 'rollback'
-  })).then(onceRolledBack).then(function onceRolledBackSucceeded(result) {
-    peerConnection._rollingBack = false;
-    return result;
-  }, function rollbackOrOnceRolledBackFailed(error) {
-    peerConnection._rollingBack = false;
-    throw error;
+  var promise;
+
+  if (!local && pendingRemoteOffer && description.type === 'answer') {
+    promise = setRemoteAnswer(peerConnection, description);
+  } else if (description.type === 'offer') {
+    if (peerConnection.signalingState !== intermediateState && peerConnection.signalingState !== 'stable') {
+      // NOTE(mmalavalli): Error message copied from Firefox.
+      return Promise.reject(new Error('Cannot set ' + (local ? 'local' : 'remote') +
+        ' offer in state ' + peerConnection.signalingState));
+    }
+
+    // We need to save this local offer in case of a rollback. We also need to
+    // check to see if the signalingState between the FirefoxRTCPeerConnection
+    // and the underlying RTCPeerConnection implementation are about to diverge.
+    // If so, we need to ensure subsequent calls to addIceCandidate will block.
+    if (!pendingLocalOffer && peerConnection._signalingStateLatch.state === 'low') {
+      peerConnection._signalingStateLatch.raise();
+    }
+    var previousSignalingState = peerConnection.signalingState;
+    setPendingLocalOffer(description);
+    promise = Promise.resolve();
+
+    // Only dispatch a signalingstatechange event if we transitioned.
+    if (peerConnection.signalingState !== previousSignalingState) {
+      promise.then(function dispatchSignalingStateChangeEvent() {
+        peerConnection.dispatchEvent(new Event('signalingstatechange'));
+      });
+    }
+  } else if (description.type === 'rollback') {
+    if (peerConnection.signalingState !== intermediateState) {
+      // NOTE(mmalavalli): Error message copied from Firefox.
+      promise = Promise.reject(new Error('Cannot rollback ' +
+        (local ? 'local' : 'remote') + ' description in ' + peerConnection.signalingState));
+    } else {
+      // Reset the pending offer.
+      clearPendingLocalOffer();
+      promise = Promise.resolve();
+      promise.then(function dispatchSignalingStateChangeEvent() {
+        peerConnection.dispatchEvent(new Event('signalingstatechange'));
+      });
+    }
+  }
+
+  return promise || peerConnection._peerConnection[setLocalDescription](description);
+}
+
+function setRemoteAnswer(peerConnection, answer) {
+  // Apply the pending local offer.
+  var pendingLocalOffer = peerConnection._pendingLocalOffer;
+  return peerConnection._peerConnection.setLocalDescription(pendingLocalOffer).then(function setLocalOfferSucceeded() {
+    peerConnection._pendingLocalOffer = null;
+    return peerConnection.setRemoteDescription(answer);
+  }).then(function setRemoteAnswerSucceeded() {
+    // NOTE(mmalavalli): The signalingStates between the FirefoxRTCPeerConnection
+    // and the underlying RTCPeerConnection implementation have converged. We
+    // can unblock any pending calls to addIceCandidate now.
+    peerConnection._signalingStateLatch.lower();
   });
 }
 


### PR DESCRIPTION
@syerrapragada 

Because of this [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1491957), more than one call to `RTCPeerConnection.createOffer` (especially after a rollback) will change the MIDs of the m= sections. Such SDPs are rejected by VMS. So, in order to work around this, we:

* Shim rollback support instead of using Firefox's native rollback support.
* Return the pending local offer, if it exists, when createOffer() is called.
