### PR TITLE
JSDK-2266 Adding back workaround for Chrome 63- RTCTrackEvent bug to support Electron 2.x.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+2.2.1 (in progress)
+===================
+
+Bug Fixes
+---------
+
+- Added back the workaround for this Chrome [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=774303)
+  in order to support Electron 2.x. (JSDK-2266)
+
 2.2.0 (January 10, 2019)
 ========================
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,12 @@ browsers.
 * Works around a [this bug](https://bugs.chromium.org/p/chromium/issues/detail?id=894231)
   in "unified-plan" SDPs where adding a `MediaStreamTrack` that was previously added and
   removed generates an SDP where the MSID does not match the `MediaStreamTrack` ID.
-
+* Does not depend on the native "track" event for "plan-b" RTCPeerConnection because
+  of [this bug](https://bugs.chromium.org/p/chromium/issues/detail?id=774303), which partly
+  refers to "ontrack" not firing when expected. We have filed
+  [this bug](https://bugs.chromium.org/p/chromium/issues/detail?id=783433) specifically for this.
+  This workaround is essential for Electron 2.x support.
+  
 #### Firefox
 * For new offers, adds support for calling `setLocalDescription` and `setRemoteDescription` in
   `have-local-offer` and `have-remote-offer` signaling states respectively.

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -101,6 +101,14 @@ function ChromeRTCPeerConnection(configuration, constraints) {
 
   var self = this;
 
+  if (sdpSemantics === 'plan-b') {
+    // NOTE(mmalavalli): Because of a bug related to "ontrack" in Chrome 63 and below,
+    // we prevent it from being delegated to ChromeRTCPeerConnection.
+    // Existing bug: https://bugs.chromium.org/p/chromium/issues/detail?id=774303
+    // Bug filed by us: https://bugs.chromium.org/p/chromium/issues/detail?id=783433
+    util.interceptEvent(this, 'track');
+  }
+
   peerConnection.addEventListener('datachannel', function ondatachannel(event) {
     shimDataChannel(event.channel);
     self.dispatchEvent(event);
@@ -275,10 +283,18 @@ ChromeRTCPeerConnection.prototype.close = function close() {
 ChromeRTCPeerConnection.prototype.createAnswer = function createAnswer() {
   var args = [].slice.call(arguments);
   var promise;
+  var isPlanB = this._sdpSemantics === 'plan-b';
   var self = this;
 
   if (this._pendingRemoteOffer) {
+    var mediaStreamTracks = isPlanB ? util.flatMap(this.getRemoteStreams(), function(mediaStream) {
+      return mediaStream.getTracks();
+    }) : [];
+
     promise = this._peerConnection.setRemoteDescription(this._pendingRemoteOffer).then(function setRemoteDescriptionSucceeded() {
+      if (isPlanB) {
+        maybeDispatchTrackEvents(self, mediaStreamTracks);
+      }
       // NOTE(mroberts): The signalingStates between the ChromeRTCPeerConnection
       // and the underlying RTCPeerConnection implementation have converged. We
       // can unblock any pending calls to addIceCandidate now.
@@ -355,6 +371,23 @@ util.delegateMethods(
   ChromeRTCPeerConnection.prototype,
   '_peerConnection');
 
+// Dispatch 'track' events to ChromeRTCPeerConnection if new
+// MediaStreamTracks have been added. This is a temporary workaround
+// for the unreliable MediaStreamTrack#addtrack event. Do this only if
+// the native RTCPeerConnection has not implemented 'ontrack'.
+function maybeDispatchTrackEvents(peerConnection, mediaStreamTracks) {
+  var currentMediaStreamTracks = util.flatMap(peerConnection.getRemoteStreams(), function(mediaStream) {
+    return mediaStream.getTracks();
+  });
+  var mediaStreamTracksAdded = util.difference(currentMediaStreamTracks, mediaStreamTracks);
+
+  mediaStreamTracksAdded.forEach(function(mediaStreamTrack) {
+    var newEvent = new Event('track');
+    newEvent.track = mediaStreamTrack;
+    peerConnection.dispatchEvent(newEvent);
+  });
+}
+
 // NOTE(mroberts): We workaround Chrome's lack of rollback support, per the
 // workaround suggested here: https://bugs.chromium.org/p/webrtc/issues/detail?id=5738#c3
 // Namely, we "fake" setting the local or remote description and instead buffer
@@ -384,9 +417,13 @@ function setDescription(peerConnection, local, description) {
   var setLocalDescription = local ? 'setLocalDescription' : 'setRemoteDescription';
   var promise;
 
+  var isPlanB = peerConnection._sdpSemantics === 'plan-b';
+  var mediaStreamTracks = isPlanB ? util.flatMap(peerConnection.getRemoteStreams(), function(mediaStream) {
+    return mediaStream.getTracks();
+  }) : [];
+
   if (!local && pendingRemoteOffer && description.type === 'answer') {
     promise = setRemoteAnswer(peerConnection, description);
-
   } else if (description.type === 'offer') {
     if (peerConnection.signalingState !== intermediateState && peerConnection.signalingState !== 'stable') {
       // NOTE(mroberts): Error message copied from Firefox.
@@ -427,16 +464,27 @@ function setDescription(peerConnection, local, description) {
     }
   }
 
-  return promise || peerConnection._peerConnection[setLocalDescription](unwrap(description));
+  return promise || peerConnection._peerConnection[setLocalDescription](unwrap(description)).then(function() {
+    if (!local && isPlanB) {
+      maybeDispatchTrackEvents(peerConnection, mediaStreamTracks);
+    }
+  });
 }
 
 function setRemoteAnswer(peerConnection, answer) {
+  var isPlanB = peerConnection._sdpSemantics === 'plan-b';
+  var mediaStreamTracks = isPlanB ? util.flatMap(peerConnection.getRemoteStreams(), function(mediaStream) {
+    return mediaStream.getTracks();
+  }) : [];
   // Apply the pending local offer.
   var pendingLocalOffer = peerConnection._pendingLocalOffer;
   return peerConnection._peerConnection.setLocalDescription(pendingLocalOffer).then(function setLocalOfferSucceeded() {
     peerConnection._pendingLocalOffer = null;
     return peerConnection.setRemoteDescription(answer);
   }).then(function setRemoteAnswerSucceeded() {
+    if (isPlanB) {
+      maybeDispatchTrackEvents(peerConnection, mediaStreamTracks);
+    }
     // NOTE(mroberts): The signalingStates between the ChromeRTCPeerConnection
     // and the underlying RTCPeerConnection implementation have converged. We
     // can unblock any pending calls to addIceCandidate now.


### PR DESCRIPTION
@syerrapragada 

A customer [reported](https://github.com/twilio/twilio-video.js/issues/507) that Electron 2.x was broken by `twilio-video.js@1.15.0`. The reason for this is that while adding support for Unified Plan, we removed the workaround for this Chrome [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=774303) which is still present in Electron 2.x. So, this PR adds the workaround back **only for Plan-B ChromeRTCPeerConnection**.