### PR TITLE
JSDK-2219 Chrome 73+: Lock in mids by calling setLocalDescription() before createOffer()

### DIFF
--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -271,7 +271,16 @@ ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {
   var options = (args.length > 1 ? args[2] : args[0]) || {};
   var self = this;
 
-  var promise = this._peerConnection.createOffer(options).then(function(offer) {
+  // NOTE(mmalavalli): Starting from Chrome 73, calling createOffer() without
+  // setLocalDescription() on the previous offer will generate new mids for
+  // RTCRtpTransceivers still under negotiation. So, in order to lock in the mids,
+  // we call setLocalDescription() on the pending local offer, if any, before
+  // calling createOffer() on the underlying RTCPeerConnection.
+  var promise = this._pendingLocalOffer
+    ? this._peerConnection.setLocalDescription(this._pendingLocalOffer)
+    : Promise.resolve();
+
+  promise = promise.then(() => this._peerConnection.createOffer(options)).then(function(offer) {
     return new ChromeRTCSessionDescription({
       type: offer.type,
       sdp: updateTrackIdsToSSRCs(self._sdpSemantics, self._tracksToSSRCs, offer.sdp)

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -280,7 +280,9 @@ ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {
     ? this._peerConnection.setLocalDescription(this._pendingLocalOffer)
     : Promise.resolve();
 
-  promise = promise.then(() => this._peerConnection.createOffer(options)).then(function(offer) {
+  promise = promise.then(function() {
+    return self._peerConnection.createOffer(options);
+  }).then(function(offer) {
     return new ChromeRTCSessionDescription({
       type: offer.type,
       sdp: updateTrackIdsToSSRCs(self._sdpSemantics, self._tracksToSSRCs, offer.sdp)

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -276,7 +276,7 @@ ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {
   // RTCRtpTransceivers still under negotiation. So, in order to lock in the mids,
   // we call setLocalDescription() on the pending local offer, if any, before
   // calling createOffer() on the underlying RTCPeerConnection.
-  var promise = this._pendingLocalOffer
+  var promise = this._sdpSemantics === 'unified-plan' && this._pendingLocalOffer
     ? this._peerConnection.setLocalDescription(this._pendingLocalOffer)
     : Promise.resolve();
 

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -250,6 +250,14 @@ describe(description, function() {
       addStream(pc, stream);
       const options = { offerToReceiveAudio: true, offerToReceiveVideo: true };
       offer1 = await pc.createOffer(options);
+
+      // NOTE(mmalavalli): Starting from Chrome 73, calling createOffer() without
+      // setLocalDescription() on the previous offer will generate new mids for
+      // RTCRtpTransceivers still under negotiation. So, in order to lock in the mids,
+      // we call setLocalDescription() on the pending local offer, if any, before
+      // calling createOffer() on the underlying RTCPeerConnection.
+      await pc.setLocalDescription(offer1);
+
       offer2 = await pc.createOffer(options);
       pc.close();
       stream.getTracks().forEach(track => track.stop());


### PR DESCRIPTION
@syerrapragada 

Starting from Chrome 73, calling `createOffer()` a second time without calling `setLocalDescription()` on the first offer will change the mids of those RTCRtpTransceivers that have not yet been fully negotiated (gone through an offer --> answer cycle).

So, this PR calls `setLocalDescription()` on the current offer before calling `createOffer()` a second time.