### PR TITLE
JSDK-2267 Adding Chrome legacy getStats() support in order to support Electron 2.x and 3.x.

### DIFF
--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -13,7 +13,7 @@ var chromeMajorVersion = isChrome
   ? parseInt(navigator.userAgent.match(/Chrome\/([0-9]+)/)[1], 10)
   : null;
 
-  /**
+/**
  * Get the standardized {@link RTCPeerConnection} statistics.
  * @param {RTCPeerConnection} peerConnection
  * @param {object} [options] - Used for testing

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -9,7 +9,11 @@ var isChrome = guess === 'chrome';
 var isFirefox = guess === 'firefox';
 var isSafari = guess === 'safari';
 
-/**
+var chromeMajorVersion = isChrome
+  ? parseInt(navigator.userAgent.match(/Chrome\/([0-9]+)/)[1], 10)
+  : null;
+
+  /**
  * Get the standardized {@link RTCPeerConnection} statistics.
  * @param {RTCPeerConnection} peerConnection
  * @param {object} [options] - Used for testing
@@ -334,6 +338,12 @@ function getTrackStats(peerConnection, track, options) {
  */
 function chromeOrSafariGetTrackStats(peerConnection, track) {
   return new Promise(function(resolve, reject) {
+    if (chromeMajorVersion && chromeMajorVersion < 67) {
+      peerConnection.getStats(function(response) {
+        resolve(standardizeChromeLegacyStats(response, track));
+      }, null, reject);
+      return;
+    }
     peerConnection.getStats(track).then(function(response) {
       resolve(standardizeChromeOrSafariStats(response));
     }, reject);
@@ -356,8 +366,82 @@ function firefoxGetTrackStats(peerConnection, track, isRemote) {
 }
 
 /**
- * Standardize the MediaStreamTrack's statistics in Chrome or Safari.
+ * Standardize the MediaStreamTrack's legacy statistics in Chrome.
  * @param {RTCStatsResponse} response
+ * @param {MediaStreamTrack} track
+ * @returns {StandardizedTrackStatsReport}
+ */
+function standardizeChromeLegacyStats(response, track) {
+  var ssrcReport = response.result().find(function(report) {
+    return report.type === 'ssrc' && report.stat('googTrackId') === track.id;
+  });
+
+  var standardizedStats = {};
+
+  if (ssrcReport) {
+    standardizedStats.timestamp = Math.round(Number(ssrcReport.timestamp));
+    standardizedStats = ssrcReport.names().reduce(function(stats, name) {
+      switch (name) {
+        case 'googCodecName':
+          stats.codecName = ssrcReport.stat(name);
+          break;
+        case 'googRtt':
+          stats.roundTripTime = Number(ssrcReport.stat(name));
+          break;
+        case 'googJitterReceived':
+          stats.jitter = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameWidthInput':
+          stats.frameWidthInput = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameHeightInput':
+          stats.frameHeightInput = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameWidthSent':
+          stats.frameWidthSent = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameHeightSent':
+          stats.frameHeightSent = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameWidthReceived':
+          stats.frameWidthReceived = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameHeightReceived':
+          stats.frameHeightReceived = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameRateInput':
+          stats.frameRateInput = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameRateSent':
+          stats.frameRateSent = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameRateReceived':
+          stats.frameRateReceived = Number(ssrcReport.stat(name));
+          break;
+        case 'ssrc':
+          stats[name] = ssrcReport.stat(name);
+          break;
+        case 'bytesReceived':
+        case 'bytesSent':
+        case 'packetsLost':
+        case 'packetsReceived':
+        case 'packetsSent':
+        case 'audioInputLevel':
+        case 'audioOutputLevel':
+          stats[name] = Number(ssrcReport.stat(name));
+          break;
+      }
+
+      return stats;
+    }, standardizedStats);
+  }
+
+  return standardizedStats;
+}
+
+/**
+ * Standardize the MediaStreamTrack's statistics in Chrome or Safari.
+ * @param {RTCStatsReport} response
  * @returns {StandardizedTrackStatsReport}
  */
 function standardizeChromeOrSafariStats(response) {

--- a/test/integration/spec/getstats.js
+++ b/test/integration/spec/getstats.js
@@ -13,16 +13,22 @@ const { guessBrowser } = require('../../../lib/util');
 const { checkIfSdpSemanticsIsSupported } = require('../../../lib/util/sdp');
 
 const guess = guessBrowser();
+const isChrome = guess === 'chrome';
 const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
 const sdpSemanticsIsSupported = checkIfSdpSemanticsIsSupported();
-const isSafariUnified = isSafari && 'currentDirection' in RTCRtpTransceiver.prototype
+
+const isSafariUnified = isSafari
+  && typeof RTCRtpTransceiver !== 'undefined'
+  && 'currentDirection' in RTCRtpTransceiver.prototype;
 
 const sdpSemanticsValues = isFirefox
   ? [null]  // Unified Plan
   : sdpSemanticsIsSupported
     ? ['plan-b', 'unified-plan']
-    : isSafariUnified ? ['unified-plan'] : [];
+    : isChrome
+      ? typeof RTCRtpTransceiver !== 'undefined' ? ['unified-plan'] : ['plan-b']
+      : isSafariUnified ? ['unified-plan'] : [];
 
 sdpSemanticsValues.forEach(sdpSemantics => {
 

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -45,7 +45,9 @@ const sdpSemanticsValues = isFirefox
   ? [null]  // Unified Plan
   : sdpSemanticsIsSupported
     ? ['plan-b', 'unified-plan']
-    : ['currentDirection' in RTCRtpTransceiver.prototype ? 'unified-plan' : 'plan-b'];
+    : [typeof RTCRtpTransceiver !== 'undefined' && 'currentDirection' in RTCRtpTransceiver.prototype
+        ? 'unified-plan'
+        : 'plan-b'];
 
 sdpSemanticsValues.forEach(sdpSemantics => {
 

--- a/test/unit/spec/getstats.js
+++ b/test/unit/spec/getstats.js
@@ -88,7 +88,6 @@ describe('getStats', function() {
           audioLevel: 0,
           frameHeight: 360,
           frameWidth: 640,
-          audioLevel: 0,
           concealedSamples: 62440,
           concealmentEvents: 91,
           detached: false,


### PR DESCRIPTION
@syerrapragada ,

In order to support Electron 2.x and 3.x, we need to use Chrome's legacy getStats(). This PR re-introduces it for Chrome versions < 67, which cover both Electron versions.