### PR TITLE
JSDK-2269

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 Bug Fixes
 ---------
 
+- Fixed a bug where, in Electron 2.x, if the remote peer adds a second
+  MediaStreamTrack after completing the negotiation for the first MediaStreamTrack,
+  calling `getStats` did not return the StandardizedTrackStatsReport for the second
+  remote MediaStreamTrack. (JSDK-2269)
 - Fixed a bug where `getStats` was throwing a TypeError in Electron 2.x and 3.x. (JSDK-2267)
 - Added back the workaround for this Chrome [bug](https://bugs.chromium.org/p/chromium/issues/detail?id=774303)
   in order to support Electron 2.x. (JSDK-2266)

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -284,7 +284,13 @@ function standardizeFirefoxActiveIceCandidatePairStats(stats) {
  */
 function getTracks(peerConnection, kind, localOrRemote) {
   var getSendersOrReceivers = localOrRemote === 'local' ? 'getSenders' : 'getReceivers';
-  if (peerConnection[getSendersOrReceivers]) {
+  // NOTE(mmalavalli): In Electron 2.x (Chrome 61), if the remote peer adds a second
+  // MediaStreamTrack after completing the negotiation for the first MediaStreamTrack,
+  // then the array returned by RTCPeerConnection.getReceivers() will contain only
+  // the RTCRtpReceiver for the first MediaStreamTrack. In order to work around this,
+  // we construct the array of remote MediaStreamTracks using
+  // RTCPeerConnection.getRemoteStreams() instead.
+  if (peerConnection[getSendersOrReceivers] && !(chromeMajorVersion && chromeMajorVersion < 66)) {
     return peerConnection[getSendersOrReceivers]().map(function(senderOrReceiver) {
       return senderOrReceiver.track;
     }).filter(function(track) {


### PR DESCRIPTION
@syerrapragada 

[Electron 2.x] Ensuring that `RTCPeerConnection.getRemoteStreams()` is used to construct the array of remote MediaStreamTracks.