### PR TITLE
JSDK-2265 Removing "plan-b" enforcement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-4.0.0 (in progress)
+3.3.0 (in progress)
 ===================
 
 New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+4.0.0 (in progress)
+===================
+
+New Features
+------------
+
+- ChromeRTCPeerConnection will now be initialized with the default SDP semantics. (JSDK-2265)
+
+Bug Fixes
+---------
+
+- Fixed a bug where getStats was throwing a TypeError in Electron 3.x. (JSDK-2267)
+
 3.2.0 (January 7, 2019)
 =======================
 

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -1,13 +1,18 @@
-/* global RTCRtpTransceiver */
 'use strict';
 
 var flatMap = require('./util').flatMap;
 var guessBrowser = require('./util').guessBrowser;
+var getSdpFormat = require('./util/sdp').getSdpFormat;
 
 var guess = guessBrowser();
 var isChrome = guess === 'chrome';
 var isFirefox = guess === 'firefox';
 var isSafari = guess === 'safari';
+var sdpFormat = getSdpFormat();
+
+var chromeMajorVersion = isChrome
+  ? parseInt(navigator.userAgent.match(/Chrome\/([0-9]+)/)[1], 10)
+  : null;
 
 /**
  * Get the standardized {@link RTCPeerConnection} statistics.
@@ -311,8 +316,7 @@ function getTrackStats(peerConnection, track, options) {
     return firefoxGetTrackStats(peerConnection, track, options.isRemote);
   }
   if (typeof options.testForSafari  !== 'undefined' || isSafari) {
-    if (typeof options.testForSafari  !== 'undefined'
-      || 'currentDirection' in RTCRtpTransceiver.prototype) {
+    if (typeof options.testForSafari  !== 'undefined' || sdpFormat === 'unified') {
       return chromeOrSafariGetTrackStats(peerConnection, track);
     }
     // NOTE(syerrapragada): getStats() is not supported on
@@ -334,6 +338,12 @@ function getTrackStats(peerConnection, track, options) {
  */
 function chromeOrSafariGetTrackStats(peerConnection, track) {
   return new Promise(function(resolve, reject) {
+    if (chromeMajorVersion && chromeMajorVersion < 67) {
+      peerConnection.getStats(function(response) {
+        resolve(standardizeChromeLegacyStats(response, track));
+      }, null, reject);
+      return;
+    }
     peerConnection.getStats(track).then(function(response) {
       resolve(standardizeChromeOrSafariStats(response));
     }, reject);
@@ -353,6 +363,80 @@ function firefoxGetTrackStats(peerConnection, track, isRemote) {
       resolve(standardizeFirefoxStats(response, isRemote));
     }, reject);
   });
+}
+
+/**
+ * Standardize the MediaStreamTrack's legacy statistics in Chrome.
+ * @param {RTCStatsResponse} response
+ * @param {MediaStreamTrack} track
+ * @returns {StandardizedTrackStatsReport}
+ */
+function standardizeChromeLegacyStats(response, track) {
+  var ssrcReport = response.result().find(function(report) {
+    return report.type === 'ssrc' && report.stat('googTrackId') === track.id;
+  });
+
+  var standardizedStats = {};
+
+  if (ssrcReport) {
+    standardizedStats.timestamp = Math.round(Number(ssrcReport.timestamp));
+    standardizedStats = ssrcReport.names().reduce(function(stats, name) {
+      switch (name) {
+        case 'googCodecName':
+          stats.codecName = ssrcReport.stat(name);
+          break;
+        case 'googRtt':
+          stats.roundTripTime = Number(ssrcReport.stat(name));
+          break;
+        case 'googJitterReceived':
+          stats.jitter = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameWidthInput':
+          stats.frameWidthInput = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameHeightInput':
+          stats.frameHeightInput = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameWidthSent':
+          stats.frameWidthSent = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameHeightSent':
+          stats.frameHeightSent = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameWidthReceived':
+          stats.frameWidthReceived = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameHeightReceived':
+          stats.frameHeightReceived = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameRateInput':
+          stats.frameRateInput = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameRateSent':
+          stats.frameRateSent = Number(ssrcReport.stat(name));
+          break;
+        case 'googFrameRateReceived':
+          stats.frameRateReceived = Number(ssrcReport.stat(name));
+          break;
+        case 'ssrc':
+          stats[name] = ssrcReport.stat(name);
+          break;
+        case 'bytesReceived':
+        case 'bytesSent':
+        case 'packetsLost':
+        case 'packetsReceived':
+        case 'packetsSent':
+        case 'audioInputLevel':
+        case 'audioOutputLevel':
+          stats[name] = Number(ssrcReport.stat(name));
+          break;
+      }
+
+      return stats;
+    }, standardizedStats);
+  }
+
+  return standardizedStats;
 }
 
 /**

--- a/lib/mediastream.js
+++ b/lib/mediastream.js
@@ -1,9 +1,7 @@
-/* globals webkitMediaStream, MediaStream */
+/* globals MediaStream */
 'use strict';
 
-if (typeof webkitMediaStream !== 'undefined') {
-  module.exports = webkitMediaStream;
-} else if (typeof MediaStream !== 'undefined') {
+if (typeof MediaStream !== 'undefined') {
   module.exports = MediaStream;
 } else {
   module.exports = function MediaStream() {

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -1,4 +1,4 @@
-/* globals RTCDataChannel, RTCSessionDescription, webkitRTCPeerConnection */
+/* globals RTCDataChannel, RTCPeerConnection, RTCSessionDescription */
 'use strict';
 
 var ChromeRTCSessionDescription = require('../rtcsessiondescription/chrome');
@@ -10,9 +10,7 @@ var RTCRtpSenderShim = require('../rtcrtpsender');
 var sdpUtils = require('../util/sdp');
 var util = require('../util');
 
-var PeerConnection = typeof RTCPeerConnection !== 'undefined'
-  ? RTCPeerConnection
-  : webkitRTCPeerConnection;
+var sdpFormat = sdpUtils.getSdpFormat();
 
 // NOTE(mroberts): This class wraps Chrome's RTCPeerConnection implementation.
 // It provides some functionality not currently present in Chrome, namely the
@@ -32,20 +30,15 @@ function ChromeRTCPeerConnection(configuration, constraints) {
 
   EventTarget.call(this);
 
-  // NOTE(mhuynh): See
-  // https://webrtc.org/web-apis/chrome/unified-plan/
-  // for transition from 'plan-b' default to 'unified-plan' as default.
-  var newConfiguration = Object.assign({ sdpSemantics: 'plan-b' }, configuration);
-  if (newConfiguration.iceTransportPolicy) {
-    newConfiguration.iceTransports = newConfiguration.iceTransportPolicy;
-  }
+  configuration = configuration || {};
+  var newConfiguration = Object.assign(configuration.iceTransportPolicy
+    ? { iceTransports: configuration.iceTransportPolicy }
+    : {}, configuration);
 
   util.interceptEvent(this, 'datachannel');
   util.interceptEvent(this, 'signalingstatechange');
 
-  /* eslint new-cap:0 */
-  var peerConnection = new PeerConnection(newConfiguration, constraints);
-  var sdpSemantics = getSdpSemantics(newConfiguration.sdpSemantics);
+  var peerConnection = new RTCPeerConnection(newConfiguration, constraints);
 
   Object.defineProperties(this, {
     _localStream: {
@@ -61,9 +54,6 @@ function ChromeRTCPeerConnection(configuration, constraints) {
     _pendingRemoteOffer: {
       value: null,
       writable: true
-    },
-    _sdpSemantics: {
-      value: sdpSemantics
     },
     _senders: {
       value: new Map()
@@ -117,13 +107,15 @@ function ChromeRTCPeerConnection(configuration, constraints) {
     // the ontrack property of the RTCPeerConnection.
   };
 
-  peerConnection.addStream(this._localStream);
-  util.proxyProperties(PeerConnection.prototype, this, peerConnection);
+  if (typeof RTCPeerConnection.prototype.addTrack !== 'function') {
+    peerConnection.addStream(this._localStream);
+  }
+  util.proxyProperties(RTCPeerConnection.prototype, this, peerConnection);
 }
 
 inherits(ChromeRTCPeerConnection, EventTarget);
 
-if (typeof PeerConnection.prototype.addTrack !== 'function') {
+if (typeof RTCPeerConnection.prototype.addTrack !== 'function') {
   // NOTE(mmalavalli): This shim supports our limited case of adding
   // all MediaStreamTracks to one MediaStream. It has been implemented this
   // keeping in mind that this is to be maintained only until "addTrack" is
@@ -244,9 +236,9 @@ ChromeRTCPeerConnection.prototype.createAnswer = function createAnswer() {
       return self._peerConnection.createAnswer();
     }).then(function createAnswerSucceeded(answer) {
       self._pendingRemoteOffer = null;
-      return new RTCSessionDescription({
+      return new ChromeRTCSessionDescription({
         type: 'answer',
-        sdp: updateTrackIdsToSSRCs(self._sdpSemantics, self._tracksToSSRCs, answer.sdp)
+        sdp: updateTrackIdsToSSRCs(sdpFormat, self._tracksToSSRCs, answer.sdp)
       });
     }, function setRemoteDescriptionOrCreateAnswerFailed(error) {
       self._pendingRemoteOffer = null;
@@ -254,9 +246,9 @@ ChromeRTCPeerConnection.prototype.createAnswer = function createAnswer() {
     });
   } else {
     promise = this._peerConnection.createAnswer().then(function(answer) {
-      return new RTCSessionDescription({
+      return new ChromeRTCSessionDescription({
         type: 'answer',
-        sdp: updateTrackIdsToSSRCs(self._sdpSemantics, self._tracksToSSRCs, answer.sdp)
+        sdp: updateTrackIdsToSSRCs(sdpFormat, self._tracksToSSRCs, answer.sdp)
       });
     });
   }
@@ -276,7 +268,7 @@ ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {
   // RTCRtpTransceivers still under negotiation. So, in order to lock in the mids,
   // we call setLocalDescription() on the pending local offer, if any, before
   // calling createOffer() on the underlying RTCPeerConnection.
-  var promise = this._sdpSemantics === 'unified-plan' && this._pendingLocalOffer
+  var promise = sdpFormat === 'unified' && this._pendingLocalOffer
     ? this._peerConnection.setLocalDescription(this._pendingLocalOffer)
     : Promise.resolve();
 
@@ -285,7 +277,7 @@ ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {
   }).then(function(offer) {
     return new ChromeRTCSessionDescription({
       type: offer.type,
-      sdp: updateTrackIdsToSSRCs(self._sdpSemantics, self._tracksToSSRCs, offer.sdp)
+      sdp: updateTrackIdsToSSRCs(sdpFormat, self._tracksToSSRCs, offer.sdp)
     });
   });
 
@@ -320,7 +312,7 @@ ChromeRTCPeerConnection.prototype.setRemoteDescription = function setRemoteDescr
 };
 
 util.delegateMethods(
-  PeerConnection.prototype,
+  RTCPeerConnection.prototype,
   ChromeRTCPeerConnection.prototype,
   '_peerConnection');
 
@@ -476,32 +468,16 @@ function shimDataChannel(dataChannel) {
 }
 
 /**
- * Get the actual `sdpSemantics`.
- * @param {SdpSemantics} sdpSemantics
- * @returns {SdpSemantics}
- */
-function getSdpSemantics(sdpSemantics) {
-  // NOTE(mmalavalli): Once Chrome stops supporting "plan-b" SDPs, it will
-  // ignore the "sdpSemantics" flag. So, in order to differentiate between
-  // versions of Chrome which support only "plan-b" SDPs and versions of Chrome
-  // which support only "unified-plan" SDPs, which check whether PeerConnection's
-  // addStream() method is present.
-  return sdpUtils.checkIfSdpSemanticsIsSupported()
-    ? sdpSemantics
-    : PeerConnection.prototype.addStream ? 'plan-b' : 'unified-plan';
-}
-
-/**
  * Update the mappings from MediaStreamTrack IDs to SSRCs as indicated by both
  * the Map from MediaStreamTrack IDs to SSRCs and the SDP itself. This method
  * ensures that SSRCs never change once announced.
- * @param {SdpSemantics} sdpSemantics
- * @param {Map<string, Set<string>>} trackIdsToSSRCs
+ * @param {'planb'|'unified'} sdpFormat
+ * @param {Map<string, Set<string>>} tracksToSSRCs
  * @param {string} sdp - an SDP whose format is determined by `sdpSemantics`
  * @returns {string} updatedSdp - updated SDP
  */
-function updateTrackIdsToSSRCs(sdpSemantics, tracksToSSRCs, sdp) {
-  return sdpSemantics === 'unified-plan'
+function updateTrackIdsToSSRCs(sdpFormat, tracksToSSRCs, sdp) {
+  return sdpFormat === 'unified'
     ? sdpUtils.updateUnifiedPlanTrackIdsToSSRCs(tracksToSSRCs, sdp)
     : sdpUtils.updatePlanBTrackIdsToSSRCs(tracksToSSRCs, sdp);
 }

--- a/lib/rtcpeerconnection/firefox.js
+++ b/lib/rtcpeerconnection/firefox.js
@@ -1,4 +1,4 @@
-/* globals mozRTCPeerConnection, RTCPeerConnection */
+/* globals RTCPeerConnection */
 'use strict';
 
 var EventTarget = require('../util/eventtarget');
@@ -6,10 +6,6 @@ var FirefoxRTCSessionDescription = require('../rtcsessiondescription/firefox');
 var inherits = require('util').inherits;
 var updateTracksToSSRCs = require('../util/sdp').updateUnifiedPlanTrackIdsToSSRCs;
 var util = require('../util');
-
-var PeerConnection = typeof RTCPeerConnection !== 'undefined'
-  ? RTCPeerConnection
-  : mozRTCPeerConnection;
 
 // NOTE(mroberts): This is a short-lived workaround. Checking the user agent
 // string might not fix every affected Firefox instance, but it should be good
@@ -48,7 +44,7 @@ function FirefoxRTCPeerConnection(configuration) {
   util.interceptEvent(this, 'signalingstatechange');
 
   /* eslint new-cap:0 */
-  var peerConnection = new PeerConnection(configuration);
+  var peerConnection = new RTCPeerConnection(configuration);
 
   Object.defineProperties(this, {
     _initiallyNegotiatedDtlsRole: {
@@ -109,7 +105,7 @@ function FirefoxRTCPeerConnection(configuration) {
     }
   });
 
-  util.proxyProperties(PeerConnection.prototype, this, peerConnection);
+  util.proxyProperties(RTCPeerConnection.prototype, this, peerConnection);
 }
 
 inherits(FirefoxRTCPeerConnection, EventTarget);
@@ -258,7 +254,7 @@ FirefoxRTCPeerConnection.prototype.close = function close() {
 };
 
 util.delegateMethods(
-  PeerConnection.prototype,
+  RTCPeerConnection.prototype,
   FirefoxRTCPeerConnection.prototype,
   '_peerConnection');
 

--- a/lib/rtcpeerconnection/safari.js
+++ b/lib/rtcpeerconnection/safari.js
@@ -1,4 +1,4 @@
-/* globals RTCPeerConnection, RTCRtpTransceiver, RTCSessionDescription */
+/* globals RTCPeerConnection, RTCSessionDescription */
 'use strict';
 
 var EventTarget = require('../util/eventtarget');
@@ -7,7 +7,7 @@ var Latch = require('../util/latch');
 var sdpUtils = require('../util/sdp');
 var util = require('../util');
 
-var isUnifiedPlan = 'currentDirection' in RTCRtpTransceiver.prototype;
+var isUnifiedPlan = sdpUtils.getSdpFormat() === 'unified';
 
 var updateTrackIdsToSSRCs = isUnifiedPlan
   ? sdpUtils.updateUnifiedPlanTrackIdsToSSRCs

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -109,15 +109,16 @@ function flatMap(list, mapFn) {
  * @returns {?string} browser - "chrome", "firefox", "safari", or null
  */
 function guessBrowser() {
-  if (typeof webkitRTCPeerConnection !== 'undefined') {
-    return 'chrome';
-  } else if (typeof mozRTCPeerConnection !== 'undefined') {
-    return 'firefox';
-  } else if (typeof RTCPeerConnection !== 'undefined') {
-    if (typeof navigator !== 'undefined' && navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) {
+  if (typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string') {
+    if (/Chrome/.test(navigator.userAgent)) {
+      return 'chrome';
+    }
+    if (/Firefox/.test(navigator.userAgent)) {
+      return 'firefox';
+    }
+    if (/Safari/.test(navigator.userAgent)) {
       return 'safari';
     }
-    // NOTE(mroberts): Could be Edge.
   }
   return null;
 }

--- a/lib/util/sdp.js
+++ b/lib/util/sdp.js
@@ -1,6 +1,57 @@
+/* globals RTCPeerConnection, RTCRtpTransceiver */
+
 'use strict';
 
 var flatMap = require('./').flatMap;
+var guessBrowser = require('./').guessBrowser;
+
+// NOTE(mmalavalli): We cache Chrome's SDP format in order to prevent
+// instantiation of more than one RTCPeerConnection.
+var chromeSdpFormat;
+
+/**
+ * Get Chrome's default SDP format.
+ * @returns {'planb'|'unified'}
+ */
+function getChromeSdpFormat() {
+  if (!chromeSdpFormat) {
+    if (typeof RTCPeerConnection !== 'undefined'
+      && 'addTransceiver' in RTCPeerConnection.prototype) {
+      try {
+        new RTCPeerConnection().addTransceiver('audio');
+        chromeSdpFormat = 'unified';
+      } catch (e) {
+        chromeSdpFormat = 'planb';
+      }
+    } else {
+      chromeSdpFormat = 'planb';
+    }
+  }
+  return chromeSdpFormat;
+}
+
+/**
+ * Get Safari's default SDP format.
+ * @returns {'planb'|'unified'}
+ */
+function getSafariSdpFormat() {
+  return typeof RTCRtpTransceiver !== 'undefined'
+    && 'currentDirection' in RTCRtpTransceiver.prototype
+      ? 'unified'
+      : 'planb';
+}
+
+/**
+ * Get the browser's default SDP format.
+ * @returns {'planb'|'unified'}
+ */
+function getSdpFormat() {
+  return {
+    chrome: getChromeSdpFormat(),
+    firefox: 'unified',
+    safari: getSafariSdpFormat()
+  }[guessBrowser()] || null;
+}
 
 /**
  * Match a pattern across lines, returning the first capture group for any
@@ -206,33 +257,7 @@ function updateUnifiedPlanTrackIdsToSSRCs(trackIdsToSSRCs, sdp) {
   return updateTrackIdsToSSRCs(getUnifiedPlanTrackIdsToSSRCs, trackIdsToSSRCs, sdp);
 }
 
-// NOTE(mroberts): We need to cache this result so that we don't create too many
-// RTCPeerConnections.
-var sdpSemanticsIsSupported;
-
-/**
- * Check whether or not `sdpSemantics` is supported.
- * @returns {boolean}
- */
-function checkIfSdpSemanticsIsSupported() {
-  if (typeof sdpSemanticsIsSupported === 'boolean') {
-    return sdpSemanticsIsSupported;
-  }
-  if (typeof RTCPeerConnection === 'undefined') {
-    sdpSemanticsIsSupported = false;
-    return sdpSemanticsIsSupported;
-  }
-  try {
-    new RTCPeerConnection({ sdpSemantics: 'bogus' });
-    sdpSemanticsIsSupported = false;
-    return sdpSemanticsIsSupported;
-  } catch (error) {
-    sdpSemanticsIsSupported = true;
-    return sdpSemanticsIsSupported;
-  }
-}
-
-exports.checkIfSdpSemanticsIsSupported = checkIfSdpSemanticsIsSupported;
+exports.getSdpFormat = getSdpFormat;
 exports.getMediaSections = getMediaSections;
 exports.getPlanBTrackIds = getPlanBTrackIds;
 exports.getUnifiedPlanTrackIds = getUnifiedPlanTrackIds;

--- a/test/integration/spec/getstats.js
+++ b/test/integration/spec/getstats.js
@@ -10,198 +10,182 @@ const getStats = require('../../../lib/getstats');
 const getUserMedia = require('../../../lib/getusermedia');
 const RTCPeerConnection = require('../../../lib/rtcpeerconnection');
 const { guessBrowser } = require('../../../lib/util');
-const { checkIfSdpSemanticsIsSupported } = require('../../../lib/util/sdp');
+const { getSdpFormat } = require('../../../lib/util/sdp');
 
 const guess = guessBrowser();
 const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
-const sdpSemanticsIsSupported = checkIfSdpSemanticsIsSupported();
-const isSafariUnified = isSafari && 'currentDirection' in RTCRtpTransceiver.prototype;
+const sdpFormat = getSdpFormat();
 
-const sdpSemanticsValues = isFirefox
-  ? [null]  // Unified Plan
-  : sdpSemanticsIsSupported
-    ? ['plan-b', 'unified-plan']
-    : isSafariUnified ? ['unified-plan'] : [];
+(isSafari && sdpFormat === 'planb' ? describe.skip : describe)(`getStats(${sdpFormat})`, function () {
+  this.timeout(10000);
 
-sdpSemanticsValues.forEach(sdpSemantics => {
+  context('should return a Promise that resolves with a StandardizedStatsResponse which has', () => {
+    let pc1;
+    let pc2;
+    let stats;
+    let stream;
 
-  const description = sdpSemantics
-    ? `getStats ("${sdpSemantics}")`
-    : 'getStats';
-
-  describe(description, function () {
-    this.timeout(10000);
-
-    context('should return a Promise that resolves with a StandardizedStatsResponse which has', () => {
-      let pc1;
-      let pc2;
-      let stats;
-      let stream;
-
-      before(async () => {
-        stream = await getUserMedia({
-          audio: true,
-          fake: true,
-          video: true
-        });
-
-        pc1 = new RTCPeerConnection({
-          iceServers: [{
-            urls: 'stun:stun.l.google.com:19302'
-          }],
-          sdpSemantics
-        });
-
-        pc2 = new RTCPeerConnection({
-          iceServers: [{
-            urls: 'stun:stun.l.google.com:19302'
-          }],
-          sdpSemantics
-        });
-
-        stream.getTracks().forEach(track => pc1.addTrack(track, stream));
-        stream.getTracks().forEach(track => pc2.addTrack(track, stream));
-
-        const deferred = {};
-        deferred.promise = new Promise((resolve, reject) => {
-          deferred.resolve = resolve;
-          deferred.reject = reject;
-        });
-
-        pc1.addEventListener('icecandidate', e => {
-          if (e.candidate) {
-            pc2.addIceCandidate(e.candidate);
-          }
-        });
-
-        pc2.addEventListener('icecandidate', e => {
-          if (e.candidate) {
-            pc1.addIceCandidate(e.candidate);
-          }
-        });
-
-        pc1.addEventListener('iceconnectionstatechange', e => {
-          if (pc1.iceConnectionState === 'connected') {
-            deferred.resolve();
-          }
-        });
-
-        const offer = await pc1.createOffer();
-        await pc1.setLocalDescription(offer);
-        await pc2.setRemoteDescription(offer);
-
-        const answer = await pc2.createAnswer();
-        await pc2.setLocalDescription(answer);
-        await pc1.setRemoteDescription(answer);
-        await deferred.promise;
-        stats = await getStats(pc1);
+    before(async () => {
+      stream = await getUserMedia({
+        audio: true,
+        fake: true,
+        video: true
       });
 
-      it('.activeIceCandidatePair', () => {
-        const {activeIceCandidatePair} = stats;
-        const {localCandidate, remoteCandidate} = activeIceCandidatePair;
+      pc1 = new RTCPeerConnection({
+        iceServers: [{
+          urls: 'stun:stun.l.google.com:19302'
+        }]
+      });
 
-        [
-          {key: 'candidateType', type: 'string'},
-          {key: 'ip', type: 'string'},
-          {key: 'port', type: 'number'},
-          {key: 'priority', type: 'number'},
-          {key: 'protocol', type: 'string'},
-          {key: 'url', type: 'string'}
-        ].forEach(({key, type}) => {
-          [localCandidate, remoteCandidate].forEach((candidate, i) => {
-            const firefoxVersion = isFirefox && navigator.userAgent.match(/Firefox\/(\d+)\./)[1];
-            if ([localCandidateStatsNullProps, remoteCandidateStatsNullProps][i][guessBrowser()](firefoxVersion).has(key)) {
-              assert.equal(candidate[key], null);
-              return;
-            }
-            if (key === 'candidateType') {
-              const candidateTypes = new Set([
-                'host',
-                'prflx',
-                'relay',
-                'srflx'
-              ]);
-              assert(candidateTypes.has(candidate[key]));
-              return;
-            }
-            if (key === 'protocol') {
-              const protocols = new Set([
-                'tcp',
-                'udp'
-              ]);
-              assert(protocols.has(candidate[key]));
-              return;
-            }
-            assert.equal(typeof candidate[key], type, `typeof candidate.${key} ("${typeof candidate[key]}") should be "${type}"`);
-          });
-        });
-        [
-          {key: 'deleted', type: 'boolean'},
-          {key: 'relayProtocol', type: 'string'}
-        ].forEach(({key, type}) => {
+      pc2 = new RTCPeerConnection({
+        iceServers: [{
+          urls: 'stun:stun.l.google.com:19302'
+        }]
+      });
+
+      stream.getTracks().forEach(track => pc1.addTrack(track, stream));
+      stream.getTracks().forEach(track => pc2.addTrack(track, stream));
+
+      const deferred = {};
+      deferred.promise = new Promise((resolve, reject) => {
+        deferred.resolve = resolve;
+        deferred.reject = reject;
+      });
+
+      pc1.addEventListener('icecandidate', e => {
+        if (e.candidate) {
+          pc2.addIceCandidate(e.candidate);
+        }
+      });
+
+      pc2.addEventListener('icecandidate', e => {
+        if (e.candidate) {
+          pc1.addIceCandidate(e.candidate);
+        }
+      });
+
+      pc1.addEventListener('iceconnectionstatechange', e => {
+        if (pc1.iceConnectionState === 'connected') {
+          deferred.resolve();
+        }
+      });
+
+      const offer = await pc1.createOffer();
+      await pc1.setLocalDescription(offer);
+      await pc2.setRemoteDescription(offer);
+
+      const answer = await pc2.createAnswer();
+      await pc2.setLocalDescription(answer);
+      await pc1.setRemoteDescription(answer);
+      await deferred.promise;
+      stats = await getStats(pc1);
+    });
+
+    it('.activeIceCandidatePair', () => {
+      const {activeIceCandidatePair} = stats;
+      const {localCandidate, remoteCandidate} = activeIceCandidatePair;
+
+      [
+        {key: 'candidateType', type: 'string'},
+        {key: 'ip', type: 'string'},
+        {key: 'port', type: 'number'},
+        {key: 'priority', type: 'number'},
+        {key: 'protocol', type: 'string'},
+        {key: 'url', type: 'string'}
+      ].forEach(({key, type}) => {
+        [localCandidate, remoteCandidate].forEach((candidate, i) => {
           const firefoxVersion = isFirefox && navigator.userAgent.match(/Firefox\/(\d+)\./)[1];
-          if (localCandidateStatsNullProps[guessBrowser()](firefoxVersion).has(key)) {
-            assert.equal(localCandidate[key], null);
+          if ([localCandidateStatsNullProps, remoteCandidateStatsNullProps][i][guess](firefoxVersion).has(key)) {
+            assert.equal(candidate[key], null);
             return;
           }
-          if (key === 'relayProtocol') {
-            assert(new Set([
+          if (key === 'candidateType') {
+            const candidateTypes = new Set([
+              'host',
+              'prflx',
+              'relay',
+              'srflx'
+            ]);
+            assert(candidateTypes.has(candidate[key]));
+            return;
+          }
+          if (key === 'protocol') {
+            const protocols = new Set([
               'tcp',
-              'tls',
               'udp'
-            ]).has(localCandidate[key]));
+            ]);
+            assert(protocols.has(candidate[key]));
             return;
           }
-          assert.equal(typeof localCandidate[key], type, `typeof localCandidate.${key} ("${typeof localCandidate[key]}") should be "${type}"`);
-        });
-
-        [
-          {key: 'availableIncomingBitrate', type: 'number'},
-          {key: 'availableOutgoingBitrate', type: 'number'},
-          {key: 'bytesReceived', type: 'number'},
-          {key: 'bytesSent', type: 'number'},
-          {key: 'consentRequestsSent', type: 'number'},
-          {key: 'currentRoundTripTime', type: 'number'},
-          {key: 'lastPacketReceivedTimestamp', type: 'number'},
-          {key: 'lastPacketSentTimestamp', type: 'number'},
-          {key: 'nominated', type: 'boolean'},
-          {key: 'priority', type: 'number'},
-          {key: 'readable', type: 'boolean'},
-          {key: 'requestsReceived', type: 'number'},
-          {key: 'requestsSent', type: 'number'},
-          {key: 'responsesReceived', type: 'number'},
-          {key: 'responsesSent', type: 'number'},
-          {key: 'retransmissionsReceived', type: 'number'},
-          {key: 'retransmissionsSent', type: 'number'},
-          {key: 'state', type: 'string'},
-          {key: 'totalRoundTripTime', type: 'number'},
-          {key: 'transportId', type: 'string'},
-          {key: 'writable', type: 'boolean'}
-        ].forEach(({key, type}) => {
-          if (activeIceCandidatePairStatsNullProps[guessBrowser()].has(key) && activeIceCandidatePair[key] === null) {
-            return;
-          }
-          if (key === 'state') {
-            assert(new Set([
-              'failed',
-              'frozen',
-              'in-progress',
-              'succeeded',
-              'waiting'
-            ]).has(activeIceCandidatePair[key]));
-            return;
-          }
-          assert.equal(typeof activeIceCandidatePair[key], type, `typeof activeIceCandidatePair.${key} ("${typeof activeIceCandidatePair[key]}") should be "${type}"`);
+          assert.equal(typeof candidate[key], type, `typeof candidate.${key} ("${typeof candidate[key]}") should be "${type}"`);
         });
       });
-
-      after(() => {
-        stream.getTracks().forEach(track => track.stop());
-        pc1.close();
-        pc2.close();
+      [
+        {key: 'deleted', type: 'boolean'},
+        {key: 'relayProtocol', type: 'string'}
+      ].forEach(({key, type}) => {
+        const firefoxVersion = isFirefox && navigator.userAgent.match(/Firefox\/(\d+)\./)[1];
+        if (localCandidateStatsNullProps[guess](firefoxVersion).has(key)) {
+          assert.equal(localCandidate[key], null);
+          return;
+        }
+        if (key === 'relayProtocol') {
+          assert(new Set([
+            'tcp',
+            'tls',
+            'udp'
+          ]).has(localCandidate[key]));
+          return;
+        }
+        assert.equal(typeof localCandidate[key], type, `typeof localCandidate.${key} ("${typeof localCandidate[key]}") should be "${type}"`);
       });
+
+      [
+        {key: 'availableIncomingBitrate', type: 'number'},
+        {key: 'availableOutgoingBitrate', type: 'number'},
+        {key: 'bytesReceived', type: 'number'},
+        {key: 'bytesSent', type: 'number'},
+        {key: 'consentRequestsSent', type: 'number'},
+        {key: 'currentRoundTripTime', type: 'number'},
+        {key: 'lastPacketReceivedTimestamp', type: 'number'},
+        {key: 'lastPacketSentTimestamp', type: 'number'},
+        {key: 'nominated', type: 'boolean'},
+        {key: 'priority', type: 'number'},
+        {key: 'readable', type: 'boolean'},
+        {key: 'requestsReceived', type: 'number'},
+        {key: 'requestsSent', type: 'number'},
+        {key: 'responsesReceived', type: 'number'},
+        {key: 'responsesSent', type: 'number'},
+        {key: 'retransmissionsReceived', type: 'number'},
+        {key: 'retransmissionsSent', type: 'number'},
+        {key: 'state', type: 'string'},
+        {key: 'totalRoundTripTime', type: 'number'},
+        {key: 'transportId', type: 'string'},
+        {key: 'writable', type: 'boolean'}
+      ].forEach(({key, type}) => {
+        if (activeIceCandidatePairStatsNullProps[guess].has(key) && activeIceCandidatePair[key] === null) {
+          return;
+        }
+        if (key === 'state') {
+          assert(new Set([
+            'failed',
+            'frozen',
+            'in-progress',
+            'succeeded',
+            'waiting'
+          ]).has(activeIceCandidatePair[key]));
+          return;
+        }
+        assert.equal(typeof activeIceCandidatePair[key], type, `typeof activeIceCandidatePair.${key} ("${typeof activeIceCandidatePair[key]}") should be "${type}"`);
+      });
+    });
+
+    after(() => {
+      stream.getTracks().forEach(track => track.stop());
+      pc1.close();
+      pc2.close();
     });
   });
 });


### PR DESCRIPTION
@syerrapragada 

This PR contains:

* Changes to remove "plan-b" enforcement and use the default SDP semantics. (JSDK-2265)
* Fix for supporting `getStats` in . Electron 3.x. (JSDK-2267)