### PR TITLE
JSDK-2219 Chrome 73+: Lock in mids by calling setLocalDescription() before createOffer()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+2.2.2 (in progress)
+===================
+
+New Features
+------------
+
+- Starting from Chrome 73 ("unified-plan" SDP semantics), `ChromeRTCPeerConnection.createOffer`,
+  when called a second time without calling `ChromeRTCPeerConnection.setLocalDescription` on the
+  previous offer, will not change the mids of any RTCRtpTransceivers still under negotiation. (JSDK-2219)
+
 2.2.1 (January 29, 2019)
 ========================
 

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -329,7 +329,18 @@ ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {
   var options = (args.length > 1 ? args[2] : args[0]) || {};
   var self = this;
 
-  var promise = this._peerConnection.createOffer(options).then(function(offer) {
+  // NOTE(mmalavalli): Starting from Chrome 73, calling createOffer() without
+  // setLocalDescription() on the previous offer will generate new mids for
+  // RTCRtpTransceivers still under negotiation. So, in order to lock in the mids,
+  // we call setLocalDescription() on the pending local offer, if any, before
+  // calling createOffer() on the underlying RTCPeerConnection.
+  var promise = this._sdpSemantics === 'unified-plan' && this._pendingLocalOffer
+    ? this._peerConnection.setLocalDescription(this._pendingLocalOffer)
+    : Promise.resolve();
+
+  promise = promise.then(function() {
+    return self._peerConnection.createOffer(options);
+  }).then(function(offer) {
     return new ChromeRTCSessionDescription({
       type: offer.type,
       sdp: updateTrackIdsToSSRCs(self._sdpSemantics, self._tracksToSSRCs, offer.sdp)

--- a/test/integration/spec/getstats.js
+++ b/test/integration/spec/getstats.js
@@ -89,7 +89,10 @@ sdpSemanticsValues.forEach(sdpSemantics => {
 
         pc1.addEventListener('iceconnectionstatechange', e => {
           if (pc1.iceConnectionState === 'connected') {
-            deferred.resolve();
+            // NOTE(mmalavalli): Sometimes, the RTCIceCandidateStats are not
+            // available exactly at this time, making this test flaky. So,
+            // we add a small delay here.
+            setTimeout(() => deferred.resolve(), 200);
           }
         });
 

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -255,6 +255,14 @@ describe(description, function() {
       addStream(pc, stream);
       const options = { offerToReceiveAudio: true, offerToReceiveVideo: true };
       offer1 = await pc.createOffer(options);
+
+      // NOTE(mmalavalli): Starting from Chrome 73, calling createOffer() without
+      // setLocalDescription() on the previous offer will generate new mids for
+      // RTCRtpTransceivers still under negotiation. So, in order to lock in the mids,
+      // we call setLocalDescription() on the pending local offer, if any, before
+      // calling createOffer() on the underlying RTCPeerConnection.
+      await pc.setLocalDescription(offer1);
+
       offer2 = await pc.createOffer(options);
       pc.close();
       stream.getTracks().forEach(track => track.stop());


### PR DESCRIPTION
@syerrapragada 

Calling setLocalDescription() on any pending local offer before calling createOffer(), in order to lock in the mids for RTCRtpTransceivers under negotiation.