### PR TITLE
Prep for 4.0.0-rc1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-3.3.0 (in progress)
+4.0.0 (in progress)
 ===================
 
 New Features

--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -73,7 +73,9 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
           prefs: {
             'media.gstreamer.enabled': false,
             'media.navigator.permission.disabled': true,
-            'media.navigator.streams.fake': true
+            'media.navigator.streams.fake': true,
+            'media.autoplay.enabled.user-gestures-needed': false,
+            'media.block-autoplay-until-in-foreground': false
           }
         }
       }


### PR DESCRIPTION
@syerrapragada 

We have to bump up the major version here because this is not compatible with earlier 2.x beta versions of twilio-video.js, especially because plan-b enforcement is removed.