### PR TITLE
JSDK-2286 Refactoring "offerToReceive" shim for "unified-plan" Safari.

### DIFF
--- a/lib/rtcpeerconnection/safari.js
+++ b/lib/rtcpeerconnection/safari.js
@@ -149,7 +149,7 @@ SafariRTCPeerConnection.prototype.createOffer = function createOffer(options) {
 
   // NOTE(mroberts): In general, this is not the way to do this; however, it's
   // good enough for our application.
-  if (options.offerToReceiveAudio && !this._audioTransceiver && !(isUnifiedPlan && hasSendersForTracksOfKind(this, 'audio'))) {
+  if (options.offerToReceiveAudio && !this._audioTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'audio'))) {
     delete options.offerToReceiveAudio;
     try {
       this._audioTransceiver = isUnifiedPlan
@@ -160,7 +160,7 @@ SafariRTCPeerConnection.prototype.createOffer = function createOffer(options) {
     }
   }
 
-  if (options.offerToReceiveVideo && !this._videoTransceiver && !(isUnifiedPlan && hasSendersForTracksOfKind(this, 'video'))) {
+  if (options.offerToReceiveVideo && !this._videoTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'video'))) {
     delete options.offerToReceiveVideo;
     try {
       this._videoTransceiver = isUnifiedPlan
@@ -312,15 +312,15 @@ function setRemoteAnswer(peerConnection, answer) {
 }
 
 /**
- * Whether a SafariRTCPeerConnection has any RTCRtpSender(s) for the given
+ * Whether a SafariRTCPeerConnection has any RTCRtpReceivers(s) for the given
  * MediaStreamTrack kind.
  * @param {SafariRTCPeerConnection} peerConnection
  * @param {'audio' | 'video'} kind
  * @returns {boolean}
  */
-function hasSendersForTracksOfKind(peerConnection, kind) {
+function hasReceiversForTracksOfKind(peerConnection, kind) {
   return !!peerConnection.getTransceivers().find(function(transceiver) {
-    return transceiver.sender && transceiver.sender.track && transceiver.sender.track.kind === kind;
+    return transceiver.receiver && transceiver.receiver.track && transceiver.receiver.track.kind === kind;
   });
 }
 

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -785,13 +785,16 @@ function testGetSenders(signalingState) {
   });
 
   context(`"${signalingState}"`, () => {
-    it('should return a list of senders', () => {
+    // NOTE(mmalavalli): Disabling this test on Safari "unified-plan" for
+    // signalingState "closed" due to this bug:
+    // https://bugs.webkit.org/show_bug.cgi?id=194890
+    (isSafari && sdpFormat === 'unified' && signalingState === 'closed' ? it.skip : it)('should return a list of senders', () => {
       const actualSenders = test.peerConnection.getSenders();
       if (isFirefox && signalingState === 'have-remote-offer') {
-        assert.deepEqual(actualSenders.length, senders.length);
+        assert.equal(actualSenders.length, senders.length);
         return;
       } else if (isSafari && sdpFormat === 'planb' && signalingState === 'have-local-offer') {
-        assert.deepEqual(actualSenders.length, senders.length + 1);
+        assert.equal(actualSenders.length, senders.length + 1);
         return;
       }
       assert.deepEqual(actualSenders, senders);


### PR DESCRIPTION
@syerrapragada 

Since our current shim is based on RTCRtpSenders, it ends up creating the "offerToReceive" RTCRtpTransceivers as soon as there are no MediaStreamTracks of a particular kind present in the RTCPeerConnection. In order to work around this, we only create "offerToReceive" RTCRtpTransceivers if there are no existing RTCRtpTransceivers with non-null RTCRtpReceiver tracks.