### PR TITLE
JSDK-2305 Enabling unified plan only for Safari 12.2+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 New Features
 ------------
 
-- ChromeRTCPeerConnection will now be initialized with the default SDP semantics. (JSDK-2265)
+- SafariRTCPeerConnection will now support Unified Plan SDPs in Safari 12.2 and above. (JSDK-2306)
 
 2.2.1 (January 29, 2019)
 ========================

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -33,7 +33,7 @@ function ChromeRTCPeerConnection(configuration, constraints) {
   configuration = configuration || {};
   var newConfiguration = Object.assign(configuration.iceTransportPolicy
     ? { iceTransports: configuration.iceTransportPolicy }
-    : {}, configuration);
+    : {}, { sdpSemantics: 'plan-b' }, configuration);
 
   util.interceptEvent(this, 'datachannel');
   util.interceptEvent(this, 'signalingstatechange');

--- a/lib/util/sdp.js
+++ b/lib/util/sdp.js
@@ -4,6 +4,31 @@
 var flatMap = require('./').flatMap;
 var guessBrowser = require('./').guessBrowser;
 
+// NOTE(mmalavalli): We cache Chrome's sdpSemantics support in order to prevent
+// instantiation of more than one RTCPeerConnection.
+var isSdpSemanticsSupported;
+
+/**
+ * Check if Chrome supports specifying sdpSemantics for an RTCPeerConnection.
+ * @return {boolean}
+ */
+function checkIfSdpSemanticsIsSupported() {
+  if (typeof isSdpSemanticsSupported === 'boolean') {
+    return isSdpSemanticsSupported;
+  }
+  if (typeof RTCPeerConnection === 'undefined') {
+    isSdpSemanticsSupported = false;
+    return isSdpSemanticsSupported;
+  }
+  try {
+    new RTCPeerConnection({ sdpSemantics: 'foo' });
+    isSdpSemanticsSupported = false;
+  } catch (e) {
+    isSdpSemanticsSupported = true;
+  }
+  return isSdpSemanticsSupported;
+}
+
 // NOTE(mmalavalli): We cache Chrome's SDP format in order to prevent
 // instantiation of more than one RTCPeerConnection.
 var chromeSdpFormat;
@@ -13,19 +38,17 @@ var chromeSdpFormat;
  * @returns {'planb'|'unified'}
  */
 function getChromeSdpFormat() {
-  if (!chromeSdpFormat) {
-    if (typeof RTCPeerConnection !== 'undefined'
-      && 'addTransceiver' in RTCPeerConnection.prototype) {
-      try {
-        new RTCPeerConnection().addTransceiver('audio');
-        chromeSdpFormat = 'unified';
-      } catch (e) {
-        chromeSdpFormat = 'planb';
-      }
-    } else {
-      chromeSdpFormat = 'planb';
-    }
+  if (typeof chromeSdpFormat === 'string') {
+    return chromeSdpFormat;
   }
+  if (checkIfSdpSemanticsIsSupported()) {
+    chromeSdpFormat = 'planb';
+    return chromeSdpFormat;
+  }
+  chromeSdpFormat = typeof RTCPeerConnection !== 'undefined'
+  && 'addStream' in RTCPeerConnection.prototype
+    ? 'planb'
+    : 'unified';
   return chromeSdpFormat;
 }
 


### PR DESCRIPTION
* Enforcing "plan-b" SDP format for Chrome
* Retaining "unified-plan" SDP format support for Safari 12.2+