### PR TITLE
update karma-electron dependency and flag

### DIFF
--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -71,7 +71,7 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
         },
         ElectronWebRTC: {
           base: 'Electron',
-          flags: ['--no-custom-user-agent'],
+          flags: ['--default-user-agent'],
         },
         FirefoxWebRTC: {
           base: 'Firefox',

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "karma": "^1.7.0",
     "karma-browserify": "^5.1.1",
     "karma-chrome-launcher": "^2.2.0",
-    "karma-electron": "github:twilio/karma-electron#1.0.0-rc1",
+    "karma-electron": "^6.1.0",
     "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "^1.3.0",
     "karma-safari-launcher": "~0.1",


### PR DESCRIPTION
To run electron tests on this repo, previously we used a fork of karma-electron (https://github.com/twilio/karma-electron) that added a new flag to disable custom user agent. 

Our change is now accepted and merged (https://github.com/twolfson/karma-electron/pull/39) into upstream repo we no more need to maintain our fork. This change takes a direct dependency on upstream repo to enable retiring our fork.

verified that electron tests passed after the change. 
```
BROWSER=electron npm run test:integration
...
Electron 5.0.0 (Mac OS X 10.14.5): Executed 289 of 298 (skipped 9) SUCCESS (2.803 secs / 0.204 secs)
TOTAL: 289 SUCCESS 
```

Similar change in: https://github.com/twilio/twilio-video.js/pull/652