### PR TITLE
small changes to help debug integration tests

### DIFF
--- a/karma/makeconf.js
+++ b/karma/makeconf.js
@@ -46,6 +46,7 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
       files,
       preprocessors,
       browserify: {
+        debug: !!process.env.DEBUG,
         transform: [
           'envify'
         ]
@@ -56,7 +57,7 @@ function makeConf(defaultFile, browserNoActivityTimeout, requires) {
       logLevel: config.LOG_DEBUG,
       autoWatch: true,
       browsers,
-      singleRun: true,
+      singleRun: !process.env.DEBUG,
       concurrency: 1,
       browserNoActivityTimeout,
       customLaunchers: {


### PR DESCRIPTION
this small change makes stepping thru our integration tests bit easier by 
-  uses `debug` flag for browserify - this lets us use sourcemaps
-  sets `singleRun:false` - which keeps the browser open after tests finished - giving deveoper chances to rerun tests with breakpoints enabled.

both the changes are enabled only when  `process.env.DEBUG` is set.