### PR TITLE
Add sdpSemantics flag

### DIFF
--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -38,10 +38,7 @@ function ChromeRTCPeerConnection(configuration, constraints) {
   util.interceptEvent(this, 'datachannel');
   util.interceptEvent(this, 'signalingstatechange');
 
-  constraints = constraints || {};
-  sdpFormat = sdpFormat || sdpUtils.getSdpFormat(constraints.sdpSemantics);
-  delete constraints.sdpSemantics;
-
+  sdpFormat = sdpFormat || sdpUtils.getSdpFormat(newConfiguration.sdpSemantics);
   var peerConnection = new RTCPeerConnection(newConfiguration, constraints);
 
   Object.defineProperties(this, {

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -239,7 +239,7 @@ ChromeRTCPeerConnection.prototype.createAnswer = function createAnswer() {
       self._pendingRemoteOffer = null;
       return new ChromeRTCSessionDescription({
         type: 'answer',
-        sdp: updateTrackIdsToSSRCs(self._tracksToSSRCs, answer.sdp)
+        sdp: updateTrackIdsToSSRCs(sdpFormat, self._tracksToSSRCs, answer.sdp)
       });
     }, function setRemoteDescriptionOrCreateAnswerFailed(error) {
       self._pendingRemoteOffer = null;
@@ -249,7 +249,7 @@ ChromeRTCPeerConnection.prototype.createAnswer = function createAnswer() {
     promise = this._peerConnection.createAnswer().then(function(answer) {
       return new ChromeRTCSessionDescription({
         type: 'answer',
-        sdp: updateTrackIdsToSSRCs(self._tracksToSSRCs, answer.sdp)
+        sdp: updateTrackIdsToSSRCs(sdpFormat, self._tracksToSSRCs, answer.sdp)
       });
     });
   }
@@ -267,7 +267,7 @@ ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {
   var promise = this._peerConnection.createOffer(options).then(function(offer) {
     return new ChromeRTCSessionDescription({
       type: offer.type,
-      sdp: updateTrackIdsToSSRCs(self._tracksToSSRCs, offer.sdp)
+      sdp: updateTrackIdsToSSRCs(sdpFormat, self._tracksToSSRCs, offer.sdp)
     });
   });
 
@@ -461,11 +461,12 @@ function shimDataChannel(dataChannel) {
  * Update the mappings from MediaStreamTrack IDs to SSRCs as indicated by both
  * the Map from MediaStreamTrack IDs to SSRCs and the SDP itself. This method
  * ensures that SSRCs never change once announced.
+ * @param {'planb'|'unified'} sdpFormat
  * @param {Map<string, Set<string>>} tracksToSSRCs
  * @param {string} sdp - an SDP whose format is determined by `sdpSemantics`
  * @returns {string} updatedSdp - updated SDP
  */
-function updateTrackIdsToSSRCs(tracksToSSRCs, sdp) {
+function updateTrackIdsToSSRCs(sdpFormat, tracksToSSRCs, sdp) {
   return sdpFormat === 'unified'
     ? sdpUtils.updateUnifiedPlanTrackIdsToSSRCs(tracksToSSRCs, sdp)
     : sdpUtils.updatePlanBTrackIdsToSSRCs(tracksToSSRCs, sdp);

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -10,7 +10,7 @@ var RTCRtpSenderShim = require('../rtcrtpsender');
 var sdpUtils = require('../util/sdp');
 var util = require('../util');
 
-var sdpFormat;
+var sdpFormat = null;
 
 // NOTE(mroberts): This class wraps Chrome's RTCPeerConnection implementation.
 // It provides some functionality not currently present in Chrome, namely the

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -10,7 +10,7 @@ var RTCRtpSenderShim = require('../rtcrtpsender');
 var sdpUtils = require('../util/sdp');
 var util = require('../util');
 
-var sdpFormat = sdpUtils.getSdpFormat();
+var sdpFormat;
 
 // NOTE(mroberts): This class wraps Chrome's RTCPeerConnection implementation.
 // It provides some functionality not currently present in Chrome, namely the
@@ -37,6 +37,10 @@ function ChromeRTCPeerConnection(configuration, constraints) {
 
   util.interceptEvent(this, 'datachannel');
   util.interceptEvent(this, 'signalingstatechange');
+
+  constraints = constraints || {};
+  sdpFormat = sdpFormat || sdpUtils.getSdpFormat(constraints.sdpSemantics);
+  delete constraints.sdpSemantics;
 
   var peerConnection = new RTCPeerConnection(newConfiguration, constraints);
 
@@ -238,7 +242,7 @@ ChromeRTCPeerConnection.prototype.createAnswer = function createAnswer() {
       self._pendingRemoteOffer = null;
       return new ChromeRTCSessionDescription({
         type: 'answer',
-        sdp: updateTrackIdsToSSRCs(sdpFormat, self._tracksToSSRCs, answer.sdp)
+        sdp: updateTrackIdsToSSRCs(self._tracksToSSRCs, answer.sdp)
       });
     }, function setRemoteDescriptionOrCreateAnswerFailed(error) {
       self._pendingRemoteOffer = null;
@@ -248,7 +252,7 @@ ChromeRTCPeerConnection.prototype.createAnswer = function createAnswer() {
     promise = this._peerConnection.createAnswer().then(function(answer) {
       return new ChromeRTCSessionDescription({
         type: 'answer',
-        sdp: updateTrackIdsToSSRCs(sdpFormat, self._tracksToSSRCs, answer.sdp)
+        sdp: updateTrackIdsToSSRCs(self._tracksToSSRCs, answer.sdp)
       });
     });
   }
@@ -266,7 +270,7 @@ ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {
   var promise = this._peerConnection.createOffer(options).then(function(offer) {
     return new ChromeRTCSessionDescription({
       type: offer.type,
-      sdp: updateTrackIdsToSSRCs(sdpFormat, self._tracksToSSRCs, offer.sdp)
+      sdp: updateTrackIdsToSSRCs(self._tracksToSSRCs, offer.sdp)
     });
   });
 
@@ -460,12 +464,11 @@ function shimDataChannel(dataChannel) {
  * Update the mappings from MediaStreamTrack IDs to SSRCs as indicated by both
  * the Map from MediaStreamTrack IDs to SSRCs and the SDP itself. This method
  * ensures that SSRCs never change once announced.
- * @param {'planb'|'unified'} sdpFormat
  * @param {Map<string, Set<string>>} tracksToSSRCs
  * @param {string} sdp - an SDP whose format is determined by `sdpSemantics`
  * @returns {string} updatedSdp - updated SDP
  */
-function updateTrackIdsToSSRCs(sdpFormat, tracksToSSRCs, sdp) {
+function updateTrackIdsToSSRCs(tracksToSSRCs, sdp) {
   return sdpFormat === 'unified'
     ? sdpUtils.updateUnifiedPlanTrackIdsToSSRCs(tracksToSSRCs, sdp)
     : sdpUtils.updatePlanBTrackIdsToSSRCs(tracksToSSRCs, sdp);

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -10,8 +10,6 @@ var RTCRtpSenderShim = require('../rtcrtpsender');
 var sdpUtils = require('../util/sdp');
 var util = require('../util');
 
-var sdpFormat = null;
-
 // NOTE(mroberts): This class wraps Chrome's RTCPeerConnection implementation.
 // It provides some functionality not currently present in Chrome, namely the
 // abilities to
@@ -38,7 +36,7 @@ function ChromeRTCPeerConnection(configuration, constraints) {
   util.interceptEvent(this, 'datachannel');
   util.interceptEvent(this, 'signalingstatechange');
 
-  sdpFormat = sdpFormat || sdpUtils.getSdpFormat(newConfiguration.sdpSemantics);
+  var sdpFormat = sdpUtils.getSdpFormat(newConfiguration.sdpSemantics);
   var peerConnection = new RTCPeerConnection(newConfiguration, constraints);
 
   Object.defineProperties(this, {
@@ -55,6 +53,9 @@ function ChromeRTCPeerConnection(configuration, constraints) {
     _pendingRemoteOffer: {
       value: null,
       writable: true
+    },
+    _sdpFormat: {
+      value: sdpFormat
     },
     _senders: {
       value: new Map()
@@ -239,7 +240,7 @@ ChromeRTCPeerConnection.prototype.createAnswer = function createAnswer() {
       self._pendingRemoteOffer = null;
       return new ChromeRTCSessionDescription({
         type: 'answer',
-        sdp: updateTrackIdsToSSRCs(sdpFormat, self._tracksToSSRCs, answer.sdp)
+        sdp: updateTrackIdsToSSRCs(self._sdpFormat, self._tracksToSSRCs, answer.sdp)
       });
     }, function setRemoteDescriptionOrCreateAnswerFailed(error) {
       self._pendingRemoteOffer = null;
@@ -249,7 +250,7 @@ ChromeRTCPeerConnection.prototype.createAnswer = function createAnswer() {
     promise = this._peerConnection.createAnswer().then(function(answer) {
       return new ChromeRTCSessionDescription({
         type: 'answer',
-        sdp: updateTrackIdsToSSRCs(sdpFormat, self._tracksToSSRCs, answer.sdp)
+        sdp: updateTrackIdsToSSRCs(self._sdpFormat, self._tracksToSSRCs, answer.sdp)
       });
     });
   }
@@ -267,7 +268,7 @@ ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {
   var promise = this._peerConnection.createOffer(options).then(function(offer) {
     return new ChromeRTCSessionDescription({
       type: offer.type,
-      sdp: updateTrackIdsToSSRCs(sdpFormat, self._tracksToSSRCs, offer.sdp)
+      sdp: updateTrackIdsToSSRCs(self._sdpFormat, self._tracksToSSRCs, offer.sdp)
     });
   });
 

--- a/lib/util/sdp.js
+++ b/lib/util/sdp.js
@@ -67,7 +67,7 @@ function getChromeSdpFormat(sdpSemantics) {
   return {
     'plan-b': 'planb',
     'unified-plan': 'unified'
-  }[sdpSemantics] || getChromeDefaultSdpFormat();
+  }[sdpSemantics];
 }
 
 /**

--- a/lib/util/sdp.js
+++ b/lib/util/sdp.js
@@ -5,6 +5,31 @@
 var flatMap = require('./').flatMap;
 var guessBrowser = require('./').guessBrowser;
 
+// NOTE(mmalavalli): We cache Chrome's sdpSemantics support in order to prevent
+// instantiation of more than one RTCPeerConnection.
+var isSdpSemanticsSupported;
+
+/**
+ * Check if Chrome supports specifying sdpSemantics for an RTCPeerConnection.
+ * @return {boolean}
+ */
+function checkIfSdpSemanticsIsSupported() {
+  if (typeof isSdpSemanticsSupported === 'boolean') {
+    return isSdpSemanticsSupported;
+  }
+  if (typeof RTCPeerConnection === 'undefined') {
+    isSdpSemanticsSupported = false;
+    return isSdpSemanticsSupported;
+  }
+  try {
+    new RTCPeerConnection({ sdpSemantics: 'foo' });
+    isSdpSemanticsSupported = false;
+  } catch (e) {
+    isSdpSemanticsSupported = true;
+  }
+  return isSdpSemanticsSupported;
+}
+
 // NOTE(mmalavalli): We cache Chrome's SDP format in order to prevent
 // instantiation of more than one RTCPeerConnection.
 var chromeSdpFormat;
@@ -13,7 +38,7 @@ var chromeSdpFormat;
  * Get Chrome's default SDP format.
  * @returns {'planb'|'unified'}
  */
-function getChromeSdpFormat() {
+function getChromeDefaultSdpFormat() {
   if (!chromeSdpFormat) {
     if (typeof RTCPeerConnection !== 'undefined'
       && 'addTransceiver' in RTCPeerConnection.prototype) {
@@ -31,6 +56,21 @@ function getChromeSdpFormat() {
 }
 
 /**
+ * Get Chrome's SDP format.
+ * @param {'plan-b'|'unified-plan'} [sdpSemantics]
+ * @param sdpSemantics
+ */
+function getChromeSdpFormat(sdpSemantics) {
+  if (!sdpSemantics || !checkIfSdpSemanticsIsSupported()) {
+    return getChromeDefaultSdpFormat();
+  }
+  return {
+    'plan-b': 'planb',
+    'unified-plan': 'unified'
+  }[sdpSemantics] || getChromeDefaultSdpFormat();
+}
+
+/**
  * Get Safari's default SDP format.
  * @returns {'planb'|'unified'}
  */
@@ -43,11 +83,12 @@ function getSafariSdpFormat() {
 
 /**
  * Get the browser's default SDP format.
+ * @param {'plan-b'|'unified-plan'} [sdpSemantics]
  * @returns {'planb'|'unified'}
  */
-function getSdpFormat() {
+function getSdpFormat(sdpSemantics) {
   return {
-    chrome: getChromeSdpFormat(),
+    chrome: getChromeSdpFormat(sdpSemantics),
     firefox: 'unified',
     safari: getSafariSdpFormat()
   }[guessBrowser()] || null;

--- a/lib/util/sdp.js
+++ b/lib/util/sdp.js
@@ -7,7 +7,7 @@ var guessBrowser = require('./').guessBrowser;
 
 // NOTE(mmalavalli): We cache Chrome's sdpSemantics support in order to prevent
 // instantiation of more than one RTCPeerConnection.
-var isSdpSemanticsSupported;
+var isSdpSemanticsSupported = null;
 
 /**
  * Check if Chrome supports specifying sdpSemantics for an RTCPeerConnection.
@@ -32,7 +32,7 @@ function checkIfSdpSemanticsIsSupported() {
 
 // NOTE(mmalavalli): We cache Chrome's SDP format in order to prevent
 // instantiation of more than one RTCPeerConnection.
-var chromeSdpFormat;
+var chromeSdpFormat = null;
 
 /**
  * Get Chrome's default SDP format.
@@ -58,7 +58,7 @@ function getChromeDefaultSdpFormat() {
 /**
  * Get Chrome's SDP format.
  * @param {'plan-b'|'unified-plan'} [sdpSemantics]
- * @param sdpSemantics
+ * @returns {'planb'|'unified'}
  */
 function getChromeSdpFormat(sdpSemantics) {
   if (!sdpSemantics || !checkIfSdpSemanticsIsSupported()) {


### PR DESCRIPTION
@makarandp0 

This PR adds a flag "sdpSemantics" to the function for calculating sdp format. This allows us to easily switch between plan-b and unified-plan using ConnectOptions (separate PR coming for that). This also solves JSDK-2392 (PeerConnection being created when the SDK is loaded). Now, we don't have to maintain `master-chrome-planb` branch anymore.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
