### PR TITLE
JSDK-2463 Undoing the updates made to "_tracksToSSRCs" when a "rollback" SDP is applied.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: node_js
 node_js:
-  - 7
+  - 10
 
 addons:
   apt:
     packages:
       - pulseaudio
+
+# https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-directly
+dist: trusty
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+4.1.1 (in progress)
+===================
+
+Bug Fixes
+---------
+
+- Fixed a bug where ChromeRTCPeerConnection and SafariRTCPeerConnection did not properly
+  update the SSRCs for MediaStreamTrack IDs in the local offer SDP after a rollback. (JSDK-2463)
+
 4.1.0 (July 12, 2019)
 =====================
 

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -40,6 +40,10 @@ function ChromeRTCPeerConnection(configuration, constraints) {
   var peerConnection = new RTCPeerConnection(newConfiguration, constraints);
 
   Object.defineProperties(this, {
+    _appliedTracksToSSRCs: {
+      value: new Map(),
+      writable: true
+    },
     _localStream: {
       value: new MediaStream()
     },
@@ -64,7 +68,8 @@ function ChromeRTCPeerConnection(configuration, constraints) {
       value: new Latch()
     },
     _tracksToSSRCs: {
-      value: new Map()
+      value: new Map(),
+      writable: true
     },
     localDescription: {
       enumerable: true,
@@ -99,6 +104,9 @@ function ChromeRTCPeerConnection(configuration, constraints) {
   });
 
   peerConnection.addEventListener('signalingstatechange', function onsignalingstatechange() {
+    if (peerConnection.signalingState === 'stable') {
+      self._appliedTracksToSSRCs = new Map(self._tracksToSSRCs);
+    }
     if (!self._pendingLocalOffer && !self._pendingRemoteOffer) {
       self.dispatchEvent.apply(self, arguments);
     }
@@ -338,7 +346,6 @@ function setDescription(peerConnection, local, description) {
 
   if (!local && pendingRemoteOffer && description.type === 'answer') {
     promise = setRemoteAnswer(peerConnection, description);
-
   } else if (description.type === 'offer') {
     if (peerConnection.signalingState !== intermediateState && peerConnection.signalingState !== 'stable') {
       // NOTE(mroberts): Error message copied from Firefox.
@@ -372,6 +379,7 @@ function setDescription(peerConnection, local, description) {
     } else {
       // Reset the pending offer.
       clearPendingLocalOffer();
+      peerConnection._tracksToSSRCs = new Map(peerConnection._appliedTracksToSSRCs);
       promise = Promise.resolve();
       promise.then(function dispatchSignalingStateChangeEvent() {
         peerConnection.dispatchEvent(new Event('signalingstatechange'));

--- a/lib/rtcpeerconnection/safari.js
+++ b/lib/rtcpeerconnection/safari.js
@@ -28,6 +28,10 @@ function SafariRTCPeerConnection(configuration) {
   var peerConnection = new RTCPeerConnection(configuration);
 
   Object.defineProperties(this, {
+    _appliedTracksToSSRCs: {
+      value: new Map(),
+      writable: true
+    },
     _audioTransceiver: {
       value: null,
       writable: true
@@ -51,7 +55,8 @@ function SafariRTCPeerConnection(configuration) {
       value: new Latch()
     },
     _tracksToSSRCs: {
-      value: new Map()
+      value: new Map(),
+      writable: true
     },
     _videoTransceiver: {
       value: null,
@@ -113,6 +118,9 @@ function SafariRTCPeerConnection(configuration) {
   peerConnection.addEventListener('signalingstatechange', function onsignalingstatechange() {
     if (self._isClosed) {
       return;
+    }
+    if (peerConnection.signalingState === 'stable') {
+      self._appliedTracksToSSRCs = new Map(self._tracksToSSRCs);
     }
     if (!self._pendingLocalOffer && !self._pendingRemoteOffer) {
       self.dispatchEvent.apply(self, arguments);
@@ -293,6 +301,7 @@ function setDescription(peerConnection, local, description) {
         (local ? 'local' : 'remote') + ' description in ' + peerConnection.signalingState));
     }
     clearPendingLocalOffer();
+    peerConnection._tracksToSSRCs = new Map(peerConnection._appliedTracksToSSRCs);
     return Promise.resolve().then(function dispatchSignalingStateChangeEvent() {
       peerConnection.dispatchEvent(new Event('signalingstatechange'));
     });


### PR DESCRIPTION
@makarandp0 

This PR is part of fixing [JSDK-2463](https://issues.corp.twilio.com/browse/JSDK-2463). We maintain a mapping of Track IDs and SSRCs to make sure that the same SSRCs appear for a given Track ID over multiple SDPs. Now, we make sure that the update applied to this map is undone when an SDP is rolled back.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
