### PR TITLE
JSDK-2522 Retain rolled back tracks to SSRCs Map when setLocalDescription() is called immediately after a rollback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+4.1.2 (in progress)
+===================
+
+Bug Fixes
+---------
+
+- Fixed a bug where ChromeRTCPeerConnection and SafariRTCPeerConnection did not restore
+  the rolled back tracks to SSRCs Map when setLocalDescription() is called immediately
+  after a rollback. (JSDK-2522)
+
 4.1.1 (September 17, 2019)
 ==========================
 

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -411,8 +411,9 @@ function setDescription(peerConnection, local, description) {
       clearPendingLocalOffer();
 
       // NOTE(mmalavalli): We store the rolled back tracks to SSRCs Map here in case
-      // setLocalDescription() is called immediately after, in which case this roll back
-      // is not due to a glare scenario and this Map should be restored.
+      // setLocalDescription() is called immediately after a rollback (without calling
+      // createOffer() or createAnswer()), in which case this roll back is not due to a
+      // glare scenario and this Map should be restored.
       peerConnection._rolledBackTracksToSSRCs = new Map(peerConnection._tracksToSSRCs);
       peerConnection._tracksToSSRCs = new Map(peerConnection._appliedTracksToSSRCs);
 

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -58,6 +58,10 @@ function ChromeRTCPeerConnection(configuration, constraints) {
       value: null,
       writable: true
     },
+    _rolledBackTracksToSSRCs: {
+      value: new Map(),
+      writable: true
+    },
     _sdpFormat: {
       value: sdpFormat
     },
@@ -246,6 +250,11 @@ ChromeRTCPeerConnection.prototype.createAnswer = function createAnswer() {
       return self._peerConnection.createAnswer();
     }).then(function createAnswerSucceeded(answer) {
       self._pendingRemoteOffer = null;
+
+      // NOTE(mmalavalli): If createAnswer() is called immediately after rolling back, then we no
+      // longer need to retain the rolled back tracks to SSRCs Map.
+      self._rolledBackTracksToSSRCs.clear();
+
       return new ChromeRTCSessionDescription({
         type: 'answer',
         sdp: updateTrackIdsToSSRCs(self._sdpFormat, self._tracksToSSRCs, answer.sdp)
@@ -256,6 +265,10 @@ ChromeRTCPeerConnection.prototype.createAnswer = function createAnswer() {
     });
   } else {
     promise = this._peerConnection.createAnswer().then(function(answer) {
+      // NOTE(mmalavalli): If createAnswer() is called immediately after rolling back, then we no
+      // longer need to retain the rolled back tracks to SSRCs Map.
+      self._rolledBackTracksToSSRCs.clear();
+
       return new ChromeRTCSessionDescription({
         type: 'answer',
         sdp: updateTrackIdsToSSRCs(self._sdpFormat, self._tracksToSSRCs, answer.sdp)
@@ -274,6 +287,10 @@ ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {
   var self = this;
 
   var promise = this._peerConnection.createOffer(options).then(function(offer) {
+    // NOTE(mmalavalli): If createOffer() is called immediately after rolling back, then we no
+    // longer need to retain the rolled back tracks to SSRCs Map.
+    self._rolledBackTracksToSSRCs.clear();
+
     return new ChromeRTCSessionDescription({
       type: offer.type,
       sdp: updateTrackIdsToSSRCs(self._sdpFormat, self._tracksToSSRCs, offer.sdp)
@@ -295,6 +312,14 @@ ChromeRTCPeerConnection.prototype.createDataChannel = function createDataChannel
 ChromeRTCPeerConnection.prototype.setLocalDescription = function setLocalDescription() {
   var args = [].slice.call(arguments);
   var description = args[0];
+
+  // NOTE(mmalavalli): If setLocalDescription() is called immediately after rolling back,
+  // then we need to restore the rolled back tracks to SSRCs Map.
+  if (this._rolledBackTracksToSSRCs.size > 0) {
+    this._tracksToSSRCs = new Map(this._rolledBackTracksToSSRCs);
+    this._rolledBackTracksToSSRCs.clear();
+  }
+
   var promise = setDescription(this, true, description);
   return args.length > 1
     ? util.legacyPromise(promise, args[1], args[2])
@@ -304,6 +329,11 @@ ChromeRTCPeerConnection.prototype.setLocalDescription = function setLocalDescrip
 ChromeRTCPeerConnection.prototype.setRemoteDescription = function setRemoteDescription() {
   var args = [].slice.call(arguments);
   var description = args[0];
+
+  // NOTE(mmalavalli): If setRemoteDescription() is called immediately after rolling back,
+  // then we no longer need to retain the rolled back tracks to SSRCs Map.
+  this._rolledBackTracksToSSRCs.clear();
+
   var promise = setDescription(this, false, description);
   return args.length > 1
     ? util.legacyPromise(promise, args[1], args[2])
@@ -379,7 +409,13 @@ function setDescription(peerConnection, local, description) {
     } else {
       // Reset the pending offer.
       clearPendingLocalOffer();
+
+      // NOTE(mmalavalli): We store the rolled back tracks to SSRCs Map here in case
+      // setLocalDescription() is called immediately after, in which case this roll back
+      // is not due to a glare scenario and this Map should be restored.
+      peerConnection._rolledBackTracksToSSRCs = new Map(peerConnection._tracksToSSRCs);
       peerConnection._tracksToSSRCs = new Map(peerConnection._appliedTracksToSSRCs);
+
       promise = Promise.resolve();
       promise.then(function dispatchSignalingStateChangeEvent() {
         peerConnection.dispatchEvent(new Event('signalingstatechange'));

--- a/lib/rtcpeerconnection/safari.js
+++ b/lib/rtcpeerconnection/safari.js
@@ -329,8 +329,9 @@ function setDescription(peerConnection, local, description) {
     clearPendingLocalOffer();
 
     // NOTE(mmalavalli): We store the rolled back tracks to SSRCs Map here in case
-    // setLocalDescription() is called immediately after, in which case this roll back
-    // is not due to a glare scenario and this Map should be restored.
+    // setLocalDescription() is called immediately aftera rollback (without calling
+    // createOffer() or createAnswer()), in which case this roll back is not due to
+    // a glare scenario and this Map should be restored.
     peerConnection._rolledBackTracksToSSRCs = new Map(peerConnection._tracksToSSRCs);
     peerConnection._tracksToSSRCs = new Map(peerConnection._appliedTracksToSSRCs);
 

--- a/lib/rtcpeerconnection/safari.js
+++ b/lib/rtcpeerconnection/safari.js
@@ -51,6 +51,10 @@ function SafariRTCPeerConnection(configuration) {
       value: null,
       writable: true
     },
+    _rolledBackTracksToSSRCs: {
+      value: new Map(),
+      writable: true
+    },
     _signalingStateLatch: {
       value: new Latch()
     },
@@ -180,6 +184,10 @@ SafariRTCPeerConnection.prototype.createOffer = function createOffer(options) {
   }
 
   return this._peerConnection.createOffer(options).then(function(offer) {
+    // NOTE(mmalavalli): If createOffer() is called immediately after rolling back,
+    // then we no longer need to retain the rolled back tracks to SSRCs Map.
+    self._rolledBackTracksToSSRCs.clear();
+
     return new RTCSessionDescription({
       type: offer.type,
       sdp: updateTrackIdsToSSRCs(self._tracksToSSRCs, offer.sdp)
@@ -196,6 +204,11 @@ SafariRTCPeerConnection.prototype.createAnswer = function createAnswer(options) 
       return self._peerConnection.createAnswer();
     }).then(function createAnswerSucceeded(answer) {
       self._pendingRemoteOffer = null;
+
+      // NOTE(mmalavalli): If createAnswer() is called immediately after rolling back, then we no
+      // longer need to retain the rolled back tracks to SSRCs Map.
+      self._rolledBackTracksToSSRCs.clear();
+
       return isUnifiedPlan ? new RTCSessionDescription({
         type: answer.type,
         sdp: updateTrackIdsToSSRCs(self._tracksToSSRCs, answer.sdp)
@@ -207,6 +220,10 @@ SafariRTCPeerConnection.prototype.createAnswer = function createAnswer(options) 
   }
 
   return this._peerConnection.createAnswer(options).then(function createAnswerSucceeded(answer) {
+    // NOTE(mmalavalli): If createAnswer() is called immediately after rolling back, then we no
+    // longer need to retain the rolled back tracks to SSRCs Map.
+    self._rolledBackTracksToSSRCs.clear();
+
     return isUnifiedPlan ? new RTCSessionDescription({
       type: answer.type,
       sdp: updateTrackIdsToSSRCs(self._tracksToSSRCs, answer.sdp)
@@ -226,10 +243,19 @@ SafariRTCPeerConnection.prototype.removeTrack = function removeTrack(sender) {
 };
 
 SafariRTCPeerConnection.prototype.setLocalDescription = function setLocalDescription(description) {
+  // NOTE(mmalavalli): If setLocalDescription() is called immediately after rolling back,
+  // then we need to restore the rolled back tracks to SSRCs Map.
+  if (this._rolledBackTracksToSSRCs.size > 0) {
+    this._tracksToSSRCs = new Map(this._rolledBackTracksToSSRCs);
+    this._rolledBackTracksToSSRCs.clear();
+  }
   return setDescription(this, true, description);
 };
 
 SafariRTCPeerConnection.prototype.setRemoteDescription = function setRemoteDescription(description) {
+  // NOTE(mmalavalli): If setRemoteDescription() is called immediately after rolling back,
+  // then we no longer need to retain the rolled back tracks to SSRCs Map.
+  this._rolledBackTracksToSSRCs.clear();
   return setDescription(this, false, description);
 };
 
@@ -301,7 +327,13 @@ function setDescription(peerConnection, local, description) {
         (local ? 'local' : 'remote') + ' description in ' + peerConnection.signalingState));
     }
     clearPendingLocalOffer();
+
+    // NOTE(mmalavalli): We store the rolled back tracks to SSRCs Map here in case
+    // setLocalDescription() is called immediately after, in which case this roll back
+    // is not due to a glare scenario and this Map should be restored.
+    peerConnection._rolledBackTracksToSSRCs = new Map(peerConnection._tracksToSSRCs);
     peerConnection._tracksToSSRCs = new Map(peerConnection._appliedTracksToSSRCs);
+
     return Promise.resolve().then(function dispatchSignalingStateChangeEvent() {
       peerConnection.dispatchEvent(new Event('signalingstatechange'));
     });

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -1409,6 +1409,11 @@ function testSetDescription(local, signalingState, sdpType) {
         'have-local-offer': 'stable'
       },
       offer: {
+        // NOTE(mmalavalli): Starting from Firefox 70, calling setRemoteDescription()
+        // from .signalingState "have-local-offer" will result in an implicit rollback
+        // of the local offer instead of raising an exception.
+        // Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1567951
+        ...(firefoxVersion > 69 ? { 'have-local-offer': 'have-remote-offer' } : {}),
         'have-remote-offer': 'have-remote-offer',
         stable: 'have-remote-offer'
       },
@@ -1500,8 +1505,8 @@ function testSetDescription(local, signalingState, sdpType) {
           assertEqualDescriptions(test.peerConnection.localDescription, nextDescription);
         });
       } else {
-        it('should not change .localDescription', () => {
-          assertEqualDescriptions(test.peerConnection.localDescription, localDescription);
+        it(`should ${firefoxVersion > 69 && sdpType === 'offer' ? 'roll back' : 'not change'} .localDescription`, () => {
+          assertEqualDescriptions(test.peerConnection.localDescription, firefoxVersion > 69 && sdpType === 'offer' ? null : localDescription);
         });
       }
 


### PR DESCRIPTION
@makarandp0 

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
