### PR TITLE
JSDK-2591: do not dereference undefined

### DIFF
--- a/lib/rtcpeerconnection/index.js
+++ b/lib/rtcpeerconnection/index.js
@@ -1,20 +1,18 @@
 'use strict';
 
-var guessBrowser = require('../util').guessBrowser;
-
-switch (guessBrowser()) {
-  case 'chrome':
-    module.exports = require('./chrome');
-    break;
-  case 'firefox':
-    module.exports = require('./firefox');
-    break;
-  case 'safari':
-    module.exports = require('./safari');
-    break;
-  default:
-    if (typeof RTCPeerConnection === 'undefined') {
+if (typeof RTCPeerConnection !== 'undefined') {
+  var guessBrowser = require('../util').guessBrowser;
+  switch (guessBrowser()) {
+    case 'chrome':
+      module.exports = require('./chrome');
       break;
-    }
-    module.exports = RTCPeerConnection;
+    case 'firefox':
+      module.exports = require('./firefox');
+      break;
+    case 'safari':
+      module.exports = require('./safari');
+      break;
+    default:
+      module.exports = RTCPeerConnection;
+  }
 }

--- a/lib/rtcsessiondescription/firefox.js
+++ b/lib/rtcsessiondescription/firefox.js
@@ -1,6 +1,5 @@
-/* globals mozRTCSessionDescription, RTCSessionDescription */
+/* globals RTCSessionDescription */
 'use strict';
-
 module.exports = typeof RTCSessionDescription !== 'undefined'
   ? RTCSessionDescription
-  : mozRTCSessionDescription;
+  : window.mozRTCSessionDescription;


### PR DESCRIPTION
when RTCPeerConnection or RTCSessionDescription is not available, (Happens in Firefox when `media.peerconnection.enabled` is set to `false` from `about:config`)  loading this module ends up with errors. 

This change avoids those undefined references.

  

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
