### PR TITLE
JSDK-2670 Handle Chrome and Firefox iOS user agents.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+4.2.0 (in progress)
+===================
+
+New Features
+------------
+
+- twilio-webrtc.js will now export `guessBrowserVersion`, which detects the major
+  and minor versions of the browser it is running on. (JSDK-2670)
+
+Bug Fixes
+---------
+
+- Fixed a bug where `guessBrowser` was falsely detecting Chrome and Firefox on iOS
+  as Safari. (JSDK-2670)
+
 4.1.3 (December 10, 2019)
 =========================
 

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -2,16 +2,16 @@
 
 var flatMap = require('./util').flatMap;
 var guessBrowser = require('./util').guessBrowser;
+var guessBrowserVersion = require('./util').guessBrowserVersion;
 var getSdpFormat = require('./util/sdp').getSdpFormat;
 
 var guess = guessBrowser();
+var guessVersion = guessBrowserVersion();
 var isChrome = guess === 'chrome';
 var isFirefox = guess === 'firefox';
 var isSafari = guess === 'safari';
 
-var chromeMajorVersion = isChrome
-  ? parseInt(navigator.userAgent.match(/Chrome\/([0-9]+)/)[1], 10)
-  : null;
+var chromeMajorVersion = isChrome ? guessVersion.major : null;
 
 var CHROME_LEGACY_MAX_AUDIO_LEVEL = 32767;
 

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -105,22 +105,65 @@ function flatMap(list, mapFn) {
 }
 
 /**
+ * Get the browser's user agent, if available.
+ * @returns {?string}
+ */
+function getUserAgent() {
+  return typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string'
+    ? navigator.userAgent
+    : null;
+}
+
+/**
  * Guess the browser.
+ * @param {string} [userAgent=navigator.userAgent]
  * @returns {?string} browser - "chrome", "firefox", "safari", or null
  */
-function guessBrowser() {
-  if (typeof navigator !== 'undefined' && typeof navigator.userAgent === 'string') {
-    if (/Chrome/.test(navigator.userAgent)) {
-      return 'chrome';
-    }
-    if (/Firefox/.test(navigator.userAgent)) {
-      return 'firefox';
-    }
-    if (/Safari/.test(navigator.userAgent)) {
-      return 'safari';
-    }
+function guessBrowser(userAgent) {
+  if (typeof userAgent === 'undefined') {
+    userAgent = getUserAgent();
+  }
+  if (/Chrome|CriOS/.test(userAgent)) {
+    return 'chrome';
+  }
+  if (/Firefox|FxiOS/.test(userAgent)) {
+    return 'firefox';
+  }
+  if (/Safari/.test(userAgent)) {
+    return 'safari';
   }
   return null;
+}
+
+/**
+ * Guess the browser version.
+ * @param {string} [userAgent=navigator.userAgent]
+ * @returns {?{major: number, minor: number}}
+ */
+function guessBrowserVersion(userAgent) {
+  if (typeof userAgent === 'undefined') {
+    userAgent = getUserAgent();
+  }
+  var prefix = {
+    chrome: 'Chrome|CriOS',
+    firefox: 'Firefox|FxiOS',
+    safari: 'Version'
+  }[guessBrowser(userAgent)];
+
+  if (!prefix) {
+    return null;
+  }
+  var regex = new RegExp('(' + prefix + ')/([^\\s]+)');
+  var match = (userAgent.match(regex) || [])[2];
+
+  if (!match) {
+    return null;
+  }
+  var versions = match.split('.').map(Number);
+  return {
+    major: isNaN(versions[0]) ? null : versions[0],
+    minor: isNaN(versions[1]) ? null : versions[1]
+  };
 }
 
 /**
@@ -241,6 +284,7 @@ exports.delegateMethods = delegateMethods;
 exports.difference = difference;
 exports.flatMap = flatMap;
 exports.guessBrowser = guessBrowser;
+exports.guessBrowserVersion = guessBrowserVersion;
 exports.interceptEvent = interceptEvent;
 exports.legacyPromise = legacyPromise;
 exports.makeUUID = makeUUID;

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -3,5 +3,6 @@
 require('./spec/getstats');
 require('./spec/getusermedia');
 
+require('./spec/util');
 require('./spec/util/latch');
 require('./spec/util/sdp');

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -1,0 +1,88 @@
+'use strict';
+
+var assert = require('assert');
+var util = require('../../../../lib/util');
+
+describe('Util', () => {
+  describe('guessBrowser', () => {
+    [
+      [
+        'Chrome Desktop',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
+        'chrome'
+      ],
+      [
+        'Chrome iOS',
+        'Mozilla/5.0 (iPad; CPU OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/79.0.3945.73 Mobile/15E148 Safari/604.1',
+        'chrome'
+      ],
+      [
+        'Firefox Desktop',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:61.0) Gecko/20100101 Firefox/69.0',
+        'firefox'
+      ],
+      [
+        'Firefox iOS',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/22.0 Safari/605.1.15',
+        'firefox'
+      ],
+      [
+        'Safari Desktop',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.4 Safari/605.1.15',
+        'safari'
+      ],
+      [
+        'Edge Desktop (Chromium)',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edg/15.15063',
+        'chrome'
+      ]
+    ].forEach(([browser, userAgent, name]) => {
+      context(`${browser} - ${userAgent}`, () => {
+        it(`should return "${name}"`, () => {
+          assert.equal(util.guessBrowser(userAgent), name);
+        });
+      });
+    });
+  });
+
+  describe('guessBrowserVersion', () => {
+    [
+      [
+        'Chrome Desktop',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36',
+        { major: 77, minor: 0 }
+      ],
+      [
+        'Chrome iOS',
+        'Mozilla/5.0 (iPad; CPU OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/79.0.3945.73 Mobile/15E148 Safari/604.1',
+        { major: 79, minor: 0 }
+      ],
+      [
+        'Firefox Desktop',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:61.0) Gecko/20100101 Firefox/69.0',
+        { major: 69, minor: 0 }
+      ],
+      [
+        'Firefox iOS',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/22.0 Safari/605.1.15',
+        { major: 22, minor: 0 }
+      ],
+      [
+        'Safari Desktop',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.4 Safari/605.1.15',
+        { major: 13, minor: 0 }
+      ],
+      [
+        'Edge Desktop (Chromium)',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edg/15.15063',
+        { major: 52, minor: 0 }
+      ]
+    ].forEach(([browser, userAgent, version]) => {
+      context(`${browser} - ${userAgent}`, () => {
+        it(`should return ${JSON.stringify(version)}`, () => {
+          assert.deepEqual(util.guessBrowserVersion(userAgent), version);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
@makarandp0 

This PR has the following changes:

* Make sure Chrome and Firefox are detected correctly on iOS.
* Consolidate browser version detection in guessBrowserVersion().

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
