### PR TITLE
JSDK-2755: get more localtrack stats

### DIFF
--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -22,7 +22,6 @@ var CHROME_LEGACY_MAX_AUDIO_LEVEL = 32767;
  * @returns {Promise.<StandardizedStatsResponse>}
  */
 function getStats(peerConnection, options) {
-  console.log('makarand: /Users/mpatwardhan/work/webrtc/lib/getstats.js!getStats');
   if (!(peerConnection && typeof peerConnection.getStats === 'function')) {
     return Promise.reject(new Error('Given PeerConnection does not support getStats'));
   }

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -22,6 +22,7 @@ var CHROME_LEGACY_MAX_AUDIO_LEVEL = 32767;
  * @returns {Promise.<StandardizedStatsResponse>}
  */
 function getStats(peerConnection, options) {
+  console.log('makarand: /Users/mpatwardhan/work/webrtc/lib/getstats.js!getStats');
   if (!(peerConnection && typeof peerConnection.getStats === 'function')) {
     return Promise.reject(new Error('Given PeerConnection does not support getStats'));
   }
@@ -448,6 +449,8 @@ function standardizeChromeLegacyStats(response, track) {
 function standardizeChromeOrSafariStats(response) {
   var inbound = null;
   var outbound = null;
+  var remoteInbound = null;
+  var remoteOutbound = null;
   var track = null;
   var codec = null;
 
@@ -465,30 +468,32 @@ function standardizeChromeOrSafariStats(response) {
       case 'codec':
         codec = stat;
         break;
+      case 'remote-inbound-rtp':
+        remoteInbound = stat;
+        break;
+      case 'remote-outbound-rtp':
+        remoteOutbound = stat;
+        break;
     }
   });
 
   var isRemote = track && track.remoteSource;
   var standardizedStats = {};
 
-  var first = isRemote ? inbound : outbound;
-  var second = track;
-  var third = codec;
+  // setup sources to look for stat
+  const statSources = [
+    isRemote ? inbound : outbound, // local rtp stats
+    track,
+    codec,
+    isRemote ? remoteOutbound : remoteInbound // remote trp stats
+  ];
 
   function getStatValue(name) {
-    if (first && typeof first[name] !== 'undefined') {
-      return first[name];
-    }
+    const sourceFound = statSources.find(statSource => {
+        return statSource && typeof statSource[name] !== 'undefined';
+      }) || null;
 
-    if (second && typeof second[name] !== 'undefined') {
-      return second[name];
-    }
-
-    if (third && typeof third[name] !== 'undefined') {
-      return third[name];
-    }
-
-    return null;
+    return sourceFound ? sourceFound[name] : null;
   }
 
   var ssrc = getStatValue('ssrc');
@@ -507,7 +512,7 @@ function standardizeChromeOrSafariStats(response) {
 
   var roundTripTime = getStatValue('roundTripTime');
   if (typeof roundTripTime === 'number') {
-    standardizedStats.roundTripTime = roundTripTime;
+    standardizedStats.roundTripTime = Math.round(roundTripTime * 1000);
   }
 
   var jitter = getStatValue('jitter');
@@ -658,7 +663,10 @@ function standardizeFirefoxStats(response, isRemote) {
 
   var roundTripTime = getStatValue('roundTripTime');
   if (typeof roundTripTime === 'number') {
-    standardizedStats.roundTripTime = roundTripTime;
+    // roundTripTime is double - measured in seconds.
+    // https://www.w3.org/TR/webrtc-stats/#dom-rtcremoteinboundrtpstreamstats-roundtriptime
+    // cover it to milliseconds (and make it integer)
+    standardizedStats.roundTripTime = Math.round(roundTripTime * 1000);
   }
 
   var jitter = getStatValue('jitter');

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -488,9 +488,9 @@ function standardizeChromeOrSafariStats(response) {
   ];
 
   function getStatValue(name) {
-    const sourceFound = statSources.find(statSource => {
-        return statSource && typeof statSource[name] !== 'undefined';
-      }) || null;
+    const sourceFound = statSources.find(function(statSource) {
+      return statSource && typeof statSource[name] !== 'undefined';
+    }) || null;
 
     return sourceFound ? sourceFound[name] : null;
   }

--- a/test/integration/spec/getstats.js
+++ b/test/integration/spec/getstats.js
@@ -17,7 +17,7 @@ const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
 const sdpFormat = getSdpFormat();
 
-(isSafari && sdpFormat === 'planb' ? describe.skip : describe)(`getStats(${sdpFormat})`, function () {
+(isSafari && sdpFormat === 'planb' ? describe.skip : describe.only)(`getStats(${sdpFormat})`, function () {
   this.timeout(10000);
 
   context('should return a Promise that resolves with a StandardizedStatsResponse which has', () => {
@@ -102,6 +102,9 @@ const sdpFormat = getSdpFormat();
           {key: 'packetsSent', type: 'number'},
           {key: 'packetsReceived', type: 'number'},
           {key: 'trackId', type: 'string'},
+          {key: 'jitter', type: 'number'},
+          {key: 'packetsLost', type: 'number'},
+          {key: 'roundTripTime', type: 'number'}
         ].forEach(({key, type}) => {
           if (trackStats.hasOwnProperty(key)) {
             assert.equal(typeof trackStats[key], type, `typeof ${stats}.${trackType}[0].${key} ("${typeof trackStats[key]}") should be "${type}"`);

--- a/test/integration/spec/getstats.js
+++ b/test/integration/spec/getstats.js
@@ -17,7 +17,7 @@ const isFirefox = guess === 'firefox';
 const isSafari = guess === 'safari';
 const sdpFormat = getSdpFormat();
 
-(isSafari && sdpFormat === 'planb' ? describe.skip : describe.only)(`getStats(${sdpFormat})`, function () {
+(isSafari && sdpFormat === 'planb' ? describe.skip : describe)(`getStats(${sdpFormat})`, function () {
   this.timeout(10000);
 
   context('should return a Promise that resolves with a StandardizedStatsResponse which has', () => {

--- a/test/unit/spec/getstats.js
+++ b/test/unit/spec/getstats.js
@@ -304,7 +304,7 @@ describe('getStats', function() {
             assert.equal(report.packetsReceived, fakeInbound.packetsReceived);
             assert.equal(report.packetsLost, fakeInbound.packetsLost);
             assert.equal(report.jitter, Math.round(fakeInbound.jitter * 1000));
-            assert.equal(report.roundTripTime, fakeInbound.roundTripTime);
+            assert.equal(report.roundTripTime, Math.round(fakeInbound.roundTripTime * 1000));
           });
       });
   });


### PR DESCRIPTION

- JSDK-2755, JSDK-2780 - update stat gathering to include stats from `remote-inbound-rtp` and `remote-output-rtp` - because that's  where you find packets_lost, roundTripTime for local tracks
- JSDK-2787 - update roundTripTime to be in int (in milliseconds) and not double (in seconds)

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
