### PR TITLE
JSDK-2799: fix test expectations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_script:
       pulseaudio --start
     fi
 
-script: npm run build
+script: ./scripts/travis-run-tests.sh
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ addons:
     packages:
       - pulseaudio
 
+# https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524
+sudo: required
+
+before_install:
+  - sudo apt-get install -y pulseaudio
+
 # https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-directly
 dist: trusty
 
@@ -34,32 +40,6 @@ matrix:
 
     - os: linux
       env: BROWSER=firefox BVER=unstable
-
-    - os: osx
-      sudo: required
-      osx_image: xcode8.3
-      env: BROWSER=safari BVER=unstable
-
-  allow_failures:
-    - env: BROWSER=safari BVER=unstable
-
-before_script:
-  - |
-    set -e
-    cd node_modules/travis-multirunner
-    if [ "${TRAVIS_OS_NAME}" == 'linux' ]; then
-      BROWSER=chrome ./setup.sh
-      BROWSER=firefox ./setup.sh
-      export CHROME_BIN=$(pwd)/browsers/bin/chrome-$BVER
-      export FIREFOX_BIN=$(pwd)/browsers/bin/firefox-$BVER
-    else
-      BROWSER=safari ./setup.sh
-    fi
-    cd ../..
-    if [ "${TRAVIS_OS_NAME}" == 'linux' ]; then
-      sh -e /etc/init.d/xvfb start
-      pulseaudio --start
-    fi
 
 script: ./scripts/travis-run-tests.sh
 

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -163,13 +163,22 @@ function standardizeChromeOrSafariActiveIceCandidatePairStats(stats) {
     { key: 'responsesSent', type: 'number' },
     { key: 'retransmissionsReceived', type: 'number' },
     { key: 'retransmissionsSent', type: 'number' },
-    { key: 'state', type: 'string' },
+    { key: 'state', type: 'string', fixup: (state) => {
+      if (state === 'inprogress') {
+        console.log('makarand: state was wrong, fixing it up.');
+        return 'in-progress';
+      }
+
+      return state;
+
+    }
+    },
     { key: 'totalRoundTripTime', type: 'number' },
     { key: 'transportId', type: 'string' },
     { key: 'writable', type: 'boolean' }
   ].reduce(function(report, keyInfo) {
     report[keyInfo.key] = typeof activeCandidatePairStats[keyInfo.key] === keyInfo.type
-      ? activeCandidatePairStats[keyInfo.key]
+      ? (keyInfo.fixup ? keyInfo.fixup(activeCandidatePairStats[keyInfo.key]) : activeCandidatePairStats[keyInfo.key])
       : null;
     return report;
   }, {

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -163,16 +163,7 @@ function standardizeChromeOrSafariActiveIceCandidatePairStats(stats) {
     { key: 'responsesSent', type: 'number' },
     { key: 'retransmissionsReceived', type: 'number' },
     { key: 'retransmissionsSent', type: 'number' },
-    { key: 'state', type: 'string', fixup: (state) => {
-      if (state === 'inprogress') {
-        console.log('makarand: state was wrong, fixing it up.');
-        return 'in-progress';
-      }
-
-      return state;
-
-    }
-    },
+    { key: 'state', type: 'string', fixup: function(state) { return state === 'inprogress' ? 'in-progress' : state; } },
     { key: 'totalRoundTripTime', type: 'number' },
     { key: 'transportId', type: 'string' },
     { key: 'writable', type: 'boolean' }

--- a/scripts/travis-run-tests.sh
+++ b/scripts/travis-run-tests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ev
+echo PWD=$PWD
+if [ "${TRAVIS_OS_NAME}" == 'linux' ]; then
+  # Upgrade to dpkg >= 1.17.5ubuntu5.8, which fixes
+  # https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
+  # (https://github.com/travis-ci/travis-ci/issues/9361)
+  sudo apt-get install -y dpkg
+fi
+npm run build

--- a/scripts/travis-run-tests.sh
+++ b/scripts/travis-run-tests.sh
@@ -1,10 +1,23 @@
 #!/bin/bash
 set -ev
 echo PWD=$PWD
+cd node_modules/travis-multirunner
 if [ "${TRAVIS_OS_NAME}" == 'linux' ]; then
   # Upgrade to dpkg >= 1.17.5ubuntu5.8, which fixes
   # https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
   # (https://github.com/travis-ci/travis-ci/issues/9361)
   sudo apt-get install -y dpkg
+  BROWSER=chrome ./setup.sh
+  BROWSER=firefox ./setup.sh
+  export CHROME_BIN=$(pwd)/browsers/bin/chrome-$BVER
+  export FIREFOX_BIN=$(pwd)/browsers/bin/firefox-$BVER
+else
+  BROWSER=safari ./setup.sh
+fi
+cd ../..
+if [ "${TRAVIS_OS_NAME}" == 'linux' ]; then
+  sh -e /etc/init.d/xvfb start
+  pulseaudio --start
+  sleep 3
 fi
 npm run build

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -854,12 +854,31 @@ function testGetReceivers(signalingState) {
   });
 }
 
+function expectIceConnectionStateChangeOnClose() {
+  // NOTE(mpatwardhan): on newer chrome builds (80.0.3983.0+),
+  //  RTCPeerConnection.close() does not fire "iceconnectionstatechange"
+  //  https://bugs.chromium.org/p/chromium/issues/detail?id=1032252
+  if (isChrome) {
+    return chromeVersion < 80;
+  } else if (isSafari) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 function expectSinglingStateChangeOnClose() {
   // NOTE(mpatwardhan): Future Chrome will no longer emit "signalingstatechange"
   // when RTCPeerConnection.close() is called.
   // https://bugs.chromium.org/p/chromium/issues/detail?id=699036&q=signalingstatechange&can=2
   // update this return value to make it conditional on the chrome version when that happens.
-  return !isChrome;
+  if (isChrome) {
+    return true;
+  } else if (isSafari) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
 function testClose(signalingState) {
@@ -928,10 +947,7 @@ function testClose(signalingState) {
         events.push('signalingstatechange');
       }
 
-      // NOTE(mpatwardhan): on newer chrome builds (80.0.3983.0+),
-      //  RTCPeerConnection.close() does not fire "iceconnectionstatechange"
-      //  https://bugs.chromium.org/p/chromium/issues/detail?id=1032252
-      if (!isChrome || chromeVersion < 80) {
+      if (expectIceConnectionStateChangeOnClose()) {
         events.push('iceconnectionstatechange');
       }
 
@@ -1638,10 +1654,7 @@ a=fingerprint:sha-256 0F:F6:1E:6F:88:AC:BA:0F:D1:4D:D7:0C:E2:B7:8E:93:CA:75:C8:8
       promisesToWaitFor.push(test.waitFor('signalingstatechange'));
     }
 
-    if (!isChrome || chromeVersion < 80) {
-      // NOTE(mpatwardhan): on newer chrome builds (80.0.3983.0+),
-      //  RTCPeerConnection.close() does not fire "iceconnectionstatechange"
-      //  https://bugs.chromium.org/p/chromium/issues/detail?id=1032252
+    if (expectIceConnectionStateChangeOnClose()) {
       promisesToWaitFor.push(test.waitFor('iceconnectionstatechange'));
     }
 

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -916,11 +916,13 @@ function testClose(signalingState) {
     } else {
       var events = [];
 
-      // NOTE(mmalavalli): Chrome 81+ will no longer emit "signalingstatechange"
+      // NOTE(mmalavalli): Chrome 83+ will no longer emit "signalingstatechange"
       // when RTCPeerConnection.close() is called.
-      if (!isChrome || chromeVersion < 81) {
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=699036&q=signalingstatechange&can=2
+      if (!isChrome || chromeVersion < 83) {
         events.push('signalingstatechange');
       }
+
       // NOTE(mpatwardhan): on newer chrome builds (80.0.3983.0+),
       //  RTCPeerConnection.close() does not fire "iceconnectionstatechange"
       //  https://bugs.chromium.org/p/chromium/issues/detail?id=1032252
@@ -1626,9 +1628,11 @@ a=fingerprint:sha-256 0F:F6:1E:6F:88:AC:BA:0F:D1:4D:D7:0C:E2:B7:8E:93:CA:75:C8:8
 
   test.close = function close() {
     const promisesToWaitFor = [test.peerConnection.close()];
-    if (!isChrome || chromeVersion < 81) {
-      // NOTE(mmalavalli): Chrome 81+ will no longer emit "signalingstatechange"
+
+    if (!isChrome || chromeVersion < 83) {
+      // NOTE(mmalavalli): Chrome 83+ will no longer emit "signalingstatechange"
       // when RTCPeerConnection.close() is called.
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=699036&q=signalingstatechange&can=2
       promisesToWaitFor.push(test.waitFor('signalingstatechange'));
     }
     if (!isChrome || chromeVersion < 80) {

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -858,8 +858,8 @@ function expectSinglingStateChangeOnClose() {
   // NOTE(mpatwardhan): Future Chrome will no longer emit "signalingstatechange"
   // when RTCPeerConnection.close() is called.
   // https://bugs.chromium.org/p/chromium/issues/detail?id=699036&q=signalingstatechange&can=2
-  // update this value to make it conditional on the chrome version when that happens.
-  return true;
+  // update this return value to make it conditional on the chrome version when that happens.
+  return !isChrome;
 }
 
 function testClose(signalingState) {

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -916,12 +916,13 @@ function testClose(signalingState) {
     } else {
       var events = [];
 
-      // NOTE(mmalavalli): Chrome 83+ will no longer emit "signalingstatechange"
+      // NOTE(mpatwardhan): Future Chrome will no longer emit "signalingstatechange"
       // when RTCPeerConnection.close() is called.
       // https://bugs.chromium.org/p/chromium/issues/detail?id=699036&q=signalingstatechange&can=2
-      if (!isChrome || chromeVersion < 83) {
-        events.push('signalingstatechange');
-      }
+      // uncomment these line when the change above lands.
+      // if (!isChrome || chromeVersion < 86) {
+      //   events.push('signalingstatechange');
+      // }
 
       // NOTE(mpatwardhan): on newer chrome builds (80.0.3983.0+),
       //  RTCPeerConnection.close() does not fire "iceconnectionstatechange"
@@ -1629,12 +1630,14 @@ a=fingerprint:sha-256 0F:F6:1E:6F:88:AC:BA:0F:D1:4D:D7:0C:E2:B7:8E:93:CA:75:C8:8
   test.close = function close() {
     const promisesToWaitFor = [test.peerConnection.close()];
 
-    if (!isChrome || chromeVersion < 83) {
-      // NOTE(mmalavalli): Chrome 83+ will no longer emit "signalingstatechange"
-      // when RTCPeerConnection.close() is called.
-      // https://bugs.chromium.org/p/chromium/issues/detail?id=699036&q=signalingstatechange&can=2
-      promisesToWaitFor.push(test.waitFor('signalingstatechange'));
-    }
+    // NOTE(mpatwardhan): Future Chrome will no longer emit "signalingstatechange"
+    // when RTCPeerConnection.close() is called.
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=699036&q=signalingstatechange&can=2
+    // uncomment these line when the change above lands.
+    // if (!isChrome || chromeVersion < 86) {
+    //   promisesToWaitFor.push(test.waitFor('signalingstatechange'));
+    // }
+
     if (!isChrome || chromeVersion < 80) {
       // NOTE(mpatwardhan): on newer chrome builds (80.0.3983.0+),
       //  RTCPeerConnection.close() does not fire "iceconnectionstatechange"

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -854,6 +854,14 @@ function testGetReceivers(signalingState) {
   });
 }
 
+function expectSinglingStateChangeOnClose() {
+  // NOTE(mpatwardhan): Future Chrome will no longer emit "signalingstatechange"
+  // when RTCPeerConnection.close() is called.
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=699036&q=signalingstatechange&can=2
+  // update this value to make it conditional on the chrome version when that happens.
+  return true;
+}
+
 function testClose(signalingState) {
   context(JSON.stringify(signalingState), () => {
     var result;
@@ -916,15 +924,9 @@ function testClose(signalingState) {
     } else {
       var events = [];
 
-      // NOTE(mpatwardhan): Future Chrome will no longer emit "signalingstatechange"
-      // when RTCPeerConnection.close() is called.
-      // https://bugs.chromium.org/p/chromium/issues/detail?id=699036&q=signalingstatechange&can=2
-      // uncomment these line when the change above lands.
-      // if (!isChrome || chromeVersion < 86) {
-      //   events.push('signalingstatechange');
-      // }
-      events.push('signalingstatechange');
-
+      if (expectSinglingStateChangeOnClose()) {
+        events.push('signalingstatechange');
+      }
 
       // NOTE(mpatwardhan): on newer chrome builds (80.0.3983.0+),
       //  RTCPeerConnection.close() does not fire "iceconnectionstatechange"
@@ -1632,14 +1634,9 @@ a=fingerprint:sha-256 0F:F6:1E:6F:88:AC:BA:0F:D1:4D:D7:0C:E2:B7:8E:93:CA:75:C8:8
   test.close = function close() {
     const promisesToWaitFor = [test.peerConnection.close()];
 
-    // NOTE(mpatwardhan): Future Chrome will no longer emit "signalingstatechange"
-    // when RTCPeerConnection.close() is called.
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=699036&q=signalingstatechange&can=2
-    // uncomment these line when the change above lands.
-    // if (!isChrome || chromeVersion < 86) {
-    //   promisesToWaitFor.push(test.waitFor('signalingstatechange'));
-    // }
-    promisesToWaitFor.push(test.waitFor('signalingstatechange'));
+    if (expectSinglingStateChangeOnClose()) {
+      promisesToWaitFor.push(test.waitFor('signalingstatechange'));
+    }
 
     if (!isChrome || chromeVersion < 80) {
       // NOTE(mpatwardhan): on newer chrome builds (80.0.3983.0+),

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -923,6 +923,8 @@ function testClose(signalingState) {
       // if (!isChrome || chromeVersion < 86) {
       //   events.push('signalingstatechange');
       // }
+      events.push('signalingstatechange');
+
 
       // NOTE(mpatwardhan): on newer chrome builds (80.0.3983.0+),
       //  RTCPeerConnection.close() does not fire "iceconnectionstatechange"
@@ -1637,6 +1639,7 @@ a=fingerprint:sha-256 0F:F6:1E:6F:88:AC:BA:0F:D1:4D:D7:0C:E2:B7:8E:93:CA:75:C8:8
     // if (!isChrome || chromeVersion < 86) {
     //   promisesToWaitFor.push(test.waitFor('signalingstatechange'));
     // }
+    promisesToWaitFor.push(test.waitFor('signalingstatechange'));
 
     if (!isChrome || chromeVersion < 80) {
       // NOTE(mpatwardhan): on newer chrome builds (80.0.3983.0+),

--- a/test/unit/spec/getstats.js
+++ b/test/unit/spec/getstats.js
@@ -1287,6 +1287,37 @@ describe('getStats', function() {
         });
       });
 
+      it('translates state=inprogress to state=in-progress', async () => {
+        const options = {
+          safariFakeStats: new Map(Object.entries({
+            RTCIceCandidatePair_Izz_OUDUFHO1: {
+              id: "RTCIceCandidatePair_Izz_OUDUFHO1",
+              timestamp: 1544547877980,
+              type: "candidate-pair",
+              availableOutgoingBitrate: 2885390,
+              bytesReceived: 11786869,
+              bytesSent: 9570568,
+              currentRoundTripTime: 0.001,
+              localCandidateId: "RTCIceCandidate_Izz",
+              nominated: true,
+              priority: 9079290933588934000,
+              remoteCandidateId: "RTCIceCandidate_OUDUFHO1",
+              requestsReceived: 24,
+              requestsSent: 1,
+              responsesReceived: 24,
+              responsesSent: 24,
+              state: "inprogress",
+              totalRoundTripTime: 0.131,
+              transportId: "RTCTransport_audio_1",
+              writable: true
+            }
+          }))
+        };
+        const peerConnection = new FakeRTCPeerConnection(options);
+        const { activeIceCandidatePair } = await getStats(peerConnection, { testForSafari: true });
+
+        assert.equal(activeIceCandidatePair.state, 'in-progress');
+      });
     });
   });
 });


### PR DESCRIPTION
Changes:
- Chrome change (to not emit `singalingstatechange` when closed) was [reverted](https://bugs.chromium.org/p/chromium/issues/detail?id=1060547), and it would [go back](https://bugs.chromium.org/p/chromium/issues/detail?id=699036) in 83+. Updated tests to match the behavior. Updated them also for Safari and Firefox to match observed behavior.

- Fixed dpkg [error](https://askubuntu.com/questions/1065231/dpkg-deb-error-archive-has-premature-member-control-tar-xz-before-contr) by updating `dpkg`
- Fixed [insights error JSDK-2826](https://issues.corp.twilio.com/browse/JSDK-2826) caused by some Safari Mobile clients sending `inprogress` for `activeCandidatePairStats.state`.  We will now update it to `in-progress`   


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
