### PR TITLE
add circleCI workflow to release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ parameters:
     type: enum
     enum: ["stable", "beta", "unstable"]
     default: "stable"
-  releaseCommand:
+  release_command:
     type: string
-    default: "foo" # when specified this mean the workflow was called from release-tool.
+    default: "echo no release command was specified" # release-tool specifies the real command.
   tag:
     type: string
     default: "" # use something like: "2.0.0-beta15" when invoking with parameters.
@@ -112,14 +112,14 @@ jobs:
       - lint
       - unit-tests
       - run: echo Wait for other jobs in the workflow to finish
-      - run: echo Release will execute "<< pipeline.parameters.releaseCommand >>"
+      - run: echo Release will execute "<< pipeline.parameters.release_command >>"
   ExecuteRelease:
     executor: docker-with-browser
     steps:
       - get-code-and-dependencies
       - lint
       - unit-tests
-      - run: echo <<pipeline.parameters.releaseCommand>>
+      - run: <<pipeline.parameters.release_command>>
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ parameters:
   custom_workflow: # runs just one custom config.
     type: boolean
     default: false
-  release_workflow:
+  release_workflow: # release tool kicks of this workflow with release_command parameter.
     type: boolean
     default: false
   browser:
@@ -105,21 +105,26 @@ jobs:
       browser: << parameters.browser >>
       bver: << parameters.bver >>
     steps: [run-tests]
-  ExecuteReleaseDummy:
-    executor: docker-with-browser
-    steps:
-      - get-code-and-dependencies
-      - lint
-      - unit-tests
-      - run: echo Wait for other jobs in the workflow to finish
-      - run: echo Release will execute "<< pipeline.parameters.release_command >>"
+
   ExecuteRelease:
     executor: docker-with-browser
+    parameters:
+      dryRun:
+        type: boolean
+        default: true
     steps:
       - get-code-and-dependencies
       - lint
       - unit-tests
-      - run: <<pipeline.parameters.release_command>>
+      - when:
+          condition: << parameters.dryRun >>
+          steps:
+            - run: echo Wait for other jobs in the workflow to finish
+            - run: echo Release will execute "<< pipeline.parameters.release_command >>"
+      - unless:
+          condition: << parameters.dryRun >>
+          steps:
+            - run: << pipeline.parameters.release_command >>
 
 workflows:
   version: 2
@@ -148,10 +153,13 @@ workflows:
             parameters:
               browser: ["chrome", "firefox"]
               bver: ["stable", "unstable", "beta"]
-      - ExecuteReleaseDummy
+      - ExecuteRelease:
+          dryRun: true
+          name: Release dry run
       - hold:
           type: approval
-          requires: [ExecuteReleaseDummy]
+          requires: [Release dry run]
       - ExecuteRelease:
+          dryRun: false
           context: sdk_js
           requires: [hold]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ parameters:
   custom_workflow: # runs just one custom config.
     type: boolean
     default: false
+  release_workflow:
+    type: boolean
+    default: false
   browser:
     type: enum
     enum: ["chrome", "firefox"]
@@ -20,6 +23,9 @@ parameters:
     type: enum
     enum: ["stable", "beta", "unstable"]
     default: "stable"
+  releaseCommand:
+    type: string
+    default: "foo" # when specified this mean the workflow was called from release-tool.
   tag:
     type: string
     default: "" # use something like: "2.0.0-beta15" when invoking with parameters.
@@ -101,6 +107,17 @@ jobs:
       browser: << parameters.browser >>
       bver: << parameters.bver >>
     steps: [run-tests]
+  ExecuteRelease:
+    executor: docker-with-browser
+    parameters:
+      releaseCommand:
+        type: string
+        default: ""
+    steps:
+      - checkout # release command builds as part of the flow.
+      - run: echo <<pipeline.parameters.releaseCommand>>
+      # - run: <<parameters.releaseCommand>>
+      #     type: approval
 
 workflows:
   version: 2
@@ -120,3 +137,17 @@ workflows:
             parameters:
               browser: ["chrome", "firefox"]
               bver: ["stable", "unstable", "beta"]
+  Release_Workflow:
+    when: << pipeline.parameters.release_workflow >>
+    jobs:
+      - run-tests-job:
+          name: << matrix.browser >>(<< matrix.bver >>)
+          matrix:
+            parameters:
+              browser: ["chrome", "firefox"]
+              bver: ["stable", "unstable", "beta"]
+      - hold:
+          type: approval
+      - ExecuteRelease: # this job has conditional steps, no-ops when pipeline.parameters.releaseCommand not specified
+          releaseCommand: << pipeline.parameters.releaseCommand >>
+          requires: [hold]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,6 @@
 # use:
 # circleci config process .circleci/config.yml > config_processed.yml
 #
-# and run any job locally with:
-# circleci local execute -c config_processed.yml --job "firefox stable group"
 version: 2.1
 parameters:
   pr_workflow:    # runs for every pull request.
@@ -107,17 +105,21 @@ jobs:
       browser: << parameters.browser >>
       bver: << parameters.bver >>
     steps: [run-tests]
+  ExecuteReleaseDummy:
+    executor: docker-with-browser
+    steps:
+      - get-code-and-dependencies
+      - lint
+      - unit-tests
+      - run: echo Wait for other jobs in the workflow to finish
+      - run: echo Release will execute "<< pipeline.parameters.releaseCommand >>"
   ExecuteRelease:
     executor: docker-with-browser
-    parameters:
-      releaseCommand:
-        type: string
-        default: ""
     steps:
-      - checkout # release command builds as part of the flow.
+      - get-code-and-dependencies
+      - lint
+      - unit-tests
       - run: echo <<pipeline.parameters.releaseCommand>>
-      # - run: <<parameters.releaseCommand>>
-      #     type: approval
 
 workflows:
   version: 2
@@ -146,8 +148,10 @@ workflows:
             parameters:
               browser: ["chrome", "firefox"]
               bver: ["stable", "unstable", "beta"]
+      - ExecuteReleaseDummy
       - hold:
           type: approval
-      - ExecuteRelease: # this job has conditional steps, no-ops when pipeline.parameters.releaseCommand not specified
-          releaseCommand: << pipeline.parameters.releaseCommand >>
+          requires: [ExecuteReleaseDummy]
+      - ExecuteRelease:
+          context: sdk_js
           requires: [hold]

--- a/.release.json
+++ b/.release.json
@@ -1,6 +1,6 @@
 {
   "type": "JavaScript",
-  "travis": true,
+  "ci": "circleci",
   "slug": "twilio/twilio-webrtc.js",
   "env": {
     "GH_REF": "github.com/twilio/twilio-webrtc.js.git"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "karma-spec-reporter": "0.0.31",
     "mocha": "^3.5.0",
     "npm-run-all": "^4.0.2",
-    "twilio-release-tool": "^0.2.11",
+    "twilio-release-tool": "^1.0.0",
     "rimraf": "^2.6.1",
     "travis-multirunner": "^4.2.3",
     "simple-git": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "karma-spec-reporter": "0.0.31",
     "mocha": "^3.5.0",
     "npm-run-all": "^4.0.2",
-    "release-tool": "^0.2.2",
+    "twilio-release-tool": "^0.2.11",
     "rimraf": "^2.6.1",
     "travis-multirunner": "^4.2.3",
     "simple-git": "^2.4.0",


### PR DESCRIPTION
This PR works with https://github.com/twilio/release-tool/pull/2 to allow release_tool to release builds using circleci

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
