### PR TITLE
JSDK-2832 Stop supporting prefixed WebRTC APIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+4.3.0 (in progress)
+===================
+
+Changes
+-------
+
+- twilio-webrtc.js will no longer support Chrome and Firefox versions that support
+  only the prefixed versions (`webkit` and `moz`) of `getUserMedia` and `RTCPeerConnection`. (JSDK-2832)
+
 4.2.1 (May 27, 2020)
 ====================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 4.3.0 (in progress)
 ===================
 
+New Features
+------------
+
+- Added a new flag `isSupported` that indicates whether native WebRTC APIs are
+  supported by the browser. (JSDK-2832)
+
 Changes
 -------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,6 @@
 4.3.0 (in progress)
 ===================
 
-New Features
-------------
-
-- Added a new flag `isSupported` that indicates whether native WebRTC APIs are
-  supported by the browser. (JSDK-2832)
-
 Changes
 -------
 

--- a/lib/getusermedia.js
+++ b/lib/getusermedia.js
@@ -1,35 +1,24 @@
+/* globals navigator */
 'use strict';
 
 /**
- * This function is very similar to <code>navigator.getUserMedia</code> except
- * that it does not use callbacks and returns a Promise for a MediaStream
+ * This function is very similar to <code>navigator.mediaDevices.getUserMedia</code>
+ * except that if no MediaStreamConstraints are provided, then bot audio and video
+ * are requested.
  * @function getUserMedia
  * @param {MediaStreamConstraints} [constraints={audio:true,video:true}] - the
- *   MediaStreamConstraints object specifying what kind of LocalMediaStream to
+ *   MediaStreamConstraints object specifying what kind of MediaStream to
  *   request from the browser (by default both audio and video)
  * @returns Promise<MediaStream>
  */
 function getUserMedia(constraints) {
-  return new Promise(function getUserMediaPromise(resolve, reject) {
-    _getUserMedia(constraints || { audio: true, video: true }, resolve, reject);
-  });
-}
-
-function _getUserMedia(constraints, onSuccess, onFailure) {
-  if (typeof window !== 'undefined' && typeof navigator !== 'undefined') {
-    if (typeof navigator.mediaDevices === 'object' &&
-        typeof navigator.mediaDevices.getUserMedia === 'function') {
-      navigator.mediaDevices.getUserMedia(constraints).then(onSuccess, onFailure);
-      return;
-    } else if (typeof navigator.webkitGetUserMedia === 'function') {
-      navigator.webkitGetUserMedia(constraints, onSuccess, onFailure);
-      return;
-    } else if (typeof navigator.mozGetUserMedia === 'function') {
-      navigator.mozGetUserMedia(constraints, onSuccess, onFailure);
-      return;
-    }
+  if (typeof navigator === 'object'
+    && typeof navigator.mediaDevices === 'object'
+    && typeof navigator.mediaDevices.getUserMedia === 'function') {
+    constraints = constraints || { audio: true, video: true };
+    return navigator.mediaDevices.getUserMedia(constraints);
   }
-  onFailure(new Error('getUserMedia is not supported'));
+  return Promise.reject(new Error('getUserMedia is not supported'));
 }
 
 module.exports = getUserMedia;

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,10 +31,6 @@ Object.defineProperties(WebRTC, {
     enumerable: true,
     value: require('./rtcsessiondescription')
   },
-  isSupported: {
-    enumerable: true,
-    value: require('./util').support()
-  },
   version: {
     enumerable: true,
     value: require('../package.json').version

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,10 @@ Object.defineProperties(WebRTC, {
     enumerable: true,
     value: require('./rtcsessiondescription')
   },
+  isSupported: {
+    enumerable: true,
+    value: require('./util').support()
+  },
   version: {
     enumerable: true,
     value: require('../package.json').version

--- a/lib/mediastream.js
+++ b/lib/mediastream.js
@@ -1,10 +1,10 @@
 /* globals MediaStream */
 'use strict';
 
-if (typeof MediaStream !== 'undefined') {
+if (typeof MediaStream === 'function') {
   module.exports = MediaStream;
 } else {
   module.exports = function MediaStream() {
-    throw new Error('WebRTC is not supported in this browser');
+    throw new Error('MediaStream is not supported');
   };
 }

--- a/lib/mediastreamtrack.js
+++ b/lib/mediastreamtrack.js
@@ -1,10 +1,10 @@
 /* global MediaStreamTrack */
 'use strict';
 
-if (typeof MediaStreamTrack !== 'undefined') {
+if (typeof MediaStreamTrack === 'function') {
   module.exports = MediaStreamTrack;
 } else {
   module.exports = function MediaStreamTrack() {
-    throw new Error('WebRTC is not supported in this browser');
+    throw new Error('MediaStreamTrack is not supported');
   };
 }

--- a/lib/rtcicecandidate.js
+++ b/lib/rtcicecandidate.js
@@ -1,12 +1,10 @@
-/* global mozRTCIceCandidate, RTCIceCandidate */
+/* global RTCIceCandidate */
 'use strict';
 
-if (typeof RTCIceCandidate !== 'undefined') {
+if (typeof RTCIceCandidate === 'function') {
   module.exports = RTCIceCandidate;
-} else if (typeof mozRTCIceCandidate !== 'undefined') {
-  module.exports = mozRTCIceCandidate;
 } else {
   module.exports = function RTCIceCandidate() {
-    throw new Error('WebRTC is unsupported');
+    throw new Error('RTCIceCandidate is not supported');
   };
 }

--- a/lib/rtcpeerconnection/index.js
+++ b/lib/rtcpeerconnection/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-if (typeof RTCPeerConnection !== 'undefined') {
+if (typeof RTCPeerConnection === 'function') {
   var guessBrowser = require('../util').guessBrowser;
   switch (guessBrowser()) {
     case 'chrome':
@@ -14,5 +14,10 @@ if (typeof RTCPeerConnection !== 'undefined') {
       break;
     default:
       module.exports = RTCPeerConnection;
+      break;
   }
+} else {
+  module.exports = function RTCPeerConnection() {
+    throw new Error('RTCPeerConnection is not supported');
+  };
 }

--- a/lib/rtcsessiondescription/firefox.js
+++ b/lib/rtcsessiondescription/firefox.js
@@ -1,5 +1,4 @@
 /* globals RTCSessionDescription */
 'use strict';
-module.exports = typeof RTCSessionDescription !== 'undefined'
-  ? RTCSessionDescription
-  : window.mozRTCSessionDescription;
+
+module.exports = RTCSessionDescription;

--- a/lib/rtcsessiondescription/index.js
+++ b/lib/rtcsessiondescription/index.js
@@ -1,17 +1,21 @@
+/* globals RTCSessionDescription */
 'use strict';
 
-var guessBrowser = require('../util').guessBrowser;
-
-switch (guessBrowser()) {
-  case 'chrome':
-    module.exports = require('./chrome');
-    break;
-  case 'firefox':
-    module.exports = require('./firefox');
-    break;
-  default:
-    if (typeof RTCSessionDescription === 'undefined') {
+if (typeof RTCSessionDescription === 'function') {
+  var guessBrowser = require('../util').guessBrowser;
+  switch (guessBrowser()) {
+    case 'chrome':
+      module.exports = require('./chrome');
       break;
-    }
-    module.exports = RTCSessionDescription;
+    case 'firefox':
+      module.exports = require('./firefox');
+      break;
+    default:
+      module.exports = RTCSessionDescription;
+      break;
+  }
+} else {
+  module.exports = function RTCSessionDescription() {
+    throw new Error('RTCSessionDescription is not supported');
+  };
 }

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -273,6 +273,17 @@ function proxyProperty(source, wrapper, target, propertyName) {
 }
 
 /**
+ * Check whether native WebRTC APIs are supported.
+ * @returns {boolean}
+ */
+function support() {
+  return typeof navigator === 'object'
+    && typeof navigator.mediaDevices === 'object'
+    && typeof navigator.mediaDevices.getUserMedia === 'function'
+    && typeof RTCPeerConnection === 'function';
+}
+
+/**
  * @typedef {object} Deferred
  * @property {Promise} promise
  * @property {function} reject
@@ -289,3 +300,4 @@ exports.interceptEvent = interceptEvent;
 exports.legacyPromise = legacyPromise;
 exports.makeUUID = makeUUID;
 exports.proxyProperties = proxyProperties;
+exports.support = support;


### PR DESCRIPTION
@makarandp0 

This PR makes sure we stop supporting Chrome (23 - 55) and Firefox (22 - 43) versions that support only the prefixed `webkit` and `moz` WebRTC APIs that are now deprecated.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
