### PR TITLE
update expectSinglingStateChangeOnClose for chromeVersion >= 85

### DIFF
--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -476,7 +476,7 @@ describe(`RTCPeerConnection(${sdpFormat})`, function() {
       const isSilent = await detectSilence(audioContext, new MediaStream([remoteTrack3]), 10000);
 
       try {
-        assert(!isSilent);
+        assert.equal(isSilent, false, 'remoteTrack was unexpectedly silent');
       } catch (error) {
         throw error;
       } finally {
@@ -869,12 +869,12 @@ function expectIceConnectionStateChangeOnClose() {
 }
 
 function expectSinglingStateChangeOnClose() {
-  // NOTE(mpatwardhan): Newer(85+) Chrome will no longer emits "signalingstatechange"
+  // NOTE(mpatwardhan): Chrome 85+ will no longer emit "signalingstatechange"
   // when RTCPeerConnection.close() is called.
   // https://bugs.chromium.org/p/chromium/issues/detail?id=699036&q=signalingstatechange&can=2
 
   if (isChrome) {
-    return chromeVersion < 85
+    return chromeVersion < 85;
   } else if (isSafari) {
     return true;
   } else {

--- a/test/integration/spec/rtcpeerconnection.js
+++ b/test/integration/spec/rtcpeerconnection.js
@@ -858,6 +858,7 @@ function expectIceConnectionStateChangeOnClose() {
   // NOTE(mpatwardhan): on newer chrome builds (80.0.3983.0+),
   //  RTCPeerConnection.close() does not fire "iceconnectionstatechange"
   //  https://bugs.chromium.org/p/chromium/issues/detail?id=1032252
+
   if (isChrome) {
     return chromeVersion < 80;
   } else if (isSafari) {
@@ -868,12 +869,12 @@ function expectIceConnectionStateChangeOnClose() {
 }
 
 function expectSinglingStateChangeOnClose() {
-  // NOTE(mpatwardhan): Future Chrome will no longer emit "signalingstatechange"
+  // NOTE(mpatwardhan): Newer(85+) Chrome will no longer emits "signalingstatechange"
   // when RTCPeerConnection.close() is called.
   // https://bugs.chromium.org/p/chromium/issues/detail?id=699036&q=signalingstatechange&can=2
-  // update this return value to make it conditional on the chrome version when that happens.
+
   if (isChrome) {
-    return true;
+    return chromeVersion < 85
   } else if (isSafari) {
     return true;
   } else {


### PR DESCRIPTION
chrome 85+ no longer sends signalingStateChange when `peerConnnection.close()` is called. update the expectation for these versions.
Ref: https://bugs.chromium.org/p/chromium/issues/detail?id=699036&q=signalingstatechange&can=2

chrome tests now pass: https://app.circleci.com/pipelines/github/twilio/twilio-webrtc.js/41/workflows/cf6aca0b-9234-4903-bf1f-1f999b8e566e

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
