### PR TITLE
JSDK-2913 Preserve es5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+4.3.1 (July 8, 2020)
+====================
+
+Changes
+-------
+
+- Removed references to `const` in order to preserve es5 support. (JSDK-2913)
+
 4.3.0 (June 5, 2020)
 ====================
 

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -480,7 +480,7 @@ function standardizeChromeOrSafariStats(response) {
   var standardizedStats = {};
 
   // setup sources to look for stat
-  const statSources = [
+  var statSources = [
     isRemote ? inbound : outbound, // local rtp stats
     track,
     codec,
@@ -488,7 +488,7 @@ function standardizeChromeOrSafariStats(response) {
   ];
 
   function getStatValue(name) {
-    const sourceFound = statSources.find(function(statSource) {
+    var sourceFound = statSources.find(function(statSource) {
       return statSource && typeof statSource[name] !== 'undefined';
     }) || null;
 


### PR DESCRIPTION
@makarandp0 

This PR makes sure es5 support is preserved by converting `const` references (introduced in #119) to `var`.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
