### PR TITLE
JSDK-2920: consolidate RTP stats when multiple found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Bug Fixes
 ---------
 
-- Fixed a bug where only one of the outbound track were returned even though multiple tracks are sent when simulcast is enabled. (JSDK-2920)
+- Fixed a bug where `getStats()` returned stats for only one of the temporal layers of a VP8 simulcast MediaStreamTrack. (JSDK-2920)
 
 
 4.3.1 (July 8, 2020)
@@ -246,4 +246,3 @@ Bug Fixes
 =======================
 
 - Factored out the WebRTC shims from twilio-video.js 1.2.0 into its own library.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
+
 4.3.2 (In Progress)
+===================
 
 Bug Fixes
 ---------
 
 - Fixed a bug where `bytesSent`, `packetsSent` returned by getStats() were set to zero when simulcast was enabled. (JSDK-2920)
 
-=======
+
 4.3.1 (July 8, 2020)
 ====================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+4.4.0 (In Progress)
+===================
+
+Bug Fixes
+---------
+
+- Fixed a bug where `bytesSent`, `packetsSent` returned by getStats() were set to zero when simulcast was enabled. (JSDK-2920)
+
+
 4.3.0 (June 5, 2020)
 ====================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Bug Fixes
 ---------
 
-- Fixed a bug where `bytesSent`, `packetsSent` returned by getStats() were set to zero when simulcast was enabled. (JSDK-2920)
+- Fixed a bug where only one of the outbound track were returned even though multiple tracks are sent when simulcast is enabled. (JSDK-2920)
 
 
 4.3.1 (July 8, 2020)

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -449,7 +449,11 @@ function standardizeChromeLegacyStats(response, track) {
  */
 function standardizeChromeOrSafariStats(response) {
   var inbound = null;
-  var outbound = []; // with simulcast enabled we could get multiple outbound-rtp entries.
+
+  // NOTE(mpatwardhan): We should expect more than one "outbound-rtp" stats for a
+  // VP8 simulcast MediaStreamTrack.
+  var outbound = [];
+
   var remoteInbound = null;
   var remoteOutbound = null;
   var track = null;

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -448,7 +448,10 @@ function standardizeChromeLegacyStats(response, track) {
  * @param {[]} rtpStatsArray
  */
 function consolidateRTPStats(rtpStatsArray) {
-  if (rtpStatsArray.length === 0) return null;
+  if (rtpStatsArray.length === 0) {
+    return null;
+  }
+
   var result = rtpStatsArray[rtpStatsArray.length - 1];
   var consolidatedStats = ['bytesSent', 'bytesReceived', 'packetsLost', 'packetsSent', 'packetsReceived'];
   consolidatedStats.forEach(stat => {

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -441,25 +441,54 @@ function standardizeChromeLegacyStats(response, track) {
 }
 
 /**
+ * returns consolidated stats for given rtpStats array.
+ * when simulcast is enabled the track stats contains multiple rtp stats
+ * corresponding to a single media track. This functions flatten them into a
+ * single rtp stats value.
+ * @param {[]} rtpStatsArray
+ */
+function consolidateRTPStats(rtpStatsArray) {
+  if (rtpStatsArray.length === 0) return null;
+  const result = rtpStatsArray[rtpStatsArray.length - 1];
+  const consolidatedStats = ['bytesSent', 'bytesReceived', 'packetsLost', 'packetsSent', 'packetsReceived'];
+  consolidatedStats.forEach(stat => {
+    let sum = 0;
+    rtpStatsArray.forEach(statSource => {
+      if (typeof statSource[stat] === 'number') {
+        sum += statSource[stat];
+      }
+    });
+
+    // TODO: debug only remove before merge.
+    if (!result[stat] && sum) {
+      console.log(`makarand: fixing ${stat}: ${result[stat]} => ${sum}`);
+    }
+    result[stat] = sum;
+  });
+
+  return result;
+}
+
+/**
  * Standardize the MediaStreamTrack's statistics in Chrome or Safari.
  * @param {RTCStatsResponse} response
  * @returns {StandardizedTrackStatsReport}
  */
 function standardizeChromeOrSafariStats(response) {
-  var inbound = null;
-  var outbound = null;
-  var remoteInbound = null;
-  var remoteOutbound = null;
+  var inbound = [];
+  var outbound = [];
+  var remoteInbound = [];
+  var remoteOutbound = [];
   var track = null;
   var codec = null;
 
   response.forEach(function(stat) {
     switch (stat.type) {
       case 'inbound-rtp':
-        inbound = stat;
+        inbound.push(stat);
         break;
       case 'outbound-rtp':
-        outbound = stat;
+        outbound.push(stat);
         break;
       case 'track':
         track = stat;
@@ -468,10 +497,10 @@ function standardizeChromeOrSafariStats(response) {
         codec = stat;
         break;
       case 'remote-inbound-rtp':
-        remoteInbound = stat;
+        remoteInbound.push(stat);
         break;
       case 'remote-outbound-rtp':
-        remoteOutbound = stat;
+        remoteOutbound.push(stat);
         break;
     }
   });
@@ -481,10 +510,10 @@ function standardizeChromeOrSafariStats(response) {
 
   // setup sources to look for stat
   const statSources = [
-    isRemote ? inbound : outbound, // local rtp stats
+    isRemote ? consolidateRTPStats(inbound) : consolidateRTPStats(outbound), // local rtp stats
     track,
     codec,
-    isRemote ? remoteOutbound : remoteInbound // remote trp stats
+    isRemote ? consolidateRTPStats(remoteOutbound) : consolidateRTPStats(remoteInbound) // remote trp stats
   ];
 
   function getStatValue(name) {

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -443,39 +443,6 @@ function standardizeChromeLegacyStats(response, track) {
 }
 
 /**
- * returns consolidated stats for given rtpStats array.
- * when simulcast is enabled the track stats contains multiple rtp stats
- * corresponding to a single media track. This functions flatten them into a
- * single rtp stats value.
- * @param {[]} rtpStatsArray
- */
-function consolidateRTPStats(rtpStatsArray) {
-  if (rtpStatsArray.length === 0) {
-    return null;
-  }
-
-  var result = rtpStatsArray[rtpStatsArray.length - 1];
-  var consolidatedStats = ['bytesSent', 'bytesReceived', 'packetsLost', 'packetsSent', 'packetsReceived'];
-  consolidatedStats.forEach(stat => {
-    let sum = 0;
-    rtpStatsArray.forEach(statSource => {
-      if (typeof statSource[stat] === 'number') {
-        sum += statSource[stat];
-      }
-    });
-
-    // TODO: debug only remove before merge.
-    if (!result[stat] && sum) {
-      console.log(`makarand: fixing ${stat}: ${result[stat]} => ${sum}`);
-    }
-    result[stat] = sum;
-  });
-
-  return result;
-}
-
-
-/**
  * Standardize the MediaStreamTrack's statistics in Chrome or Safari.
  * @param {RTCStatsResponse} response
  * @returns {Array<StandardizedTrackStatsReport>}

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -60,9 +60,11 @@ function _getStats(peerConnection, options) {
     return tracks.map(function(track) {
       return getTrackStats(peerConnection, track, Object.assign({
         isRemote: isRemote
-      }, options)).then(function(stats) {
-        stats.trackId = track.id;
-        statsResponse[statsArrayName].push(stats);
+      }, options)).then(function(trackStatsArray) {
+        trackStatsArray.forEach(trackStats => {
+          trackStats.trackId = track.id;
+          statsResponse[statsArrayName].push(trackStats);
+        });
       });
     });
   });
@@ -305,7 +307,7 @@ function getTracks(peerConnection, kind, localOrRemote) {
  * @param {RTCPeerConnection} peerConnection
  * @param {MediaStreamTrack} track
  * @param {object} [options] - Used for testing
- * @returns {Promise.<StandardizedTrackStatsReport>}
+ * @returns {Promise.<Array<StandardizedTrackStatsReport>>}
  */
 function getTrackStats(peerConnection, track, options) {
   options = options || {};
@@ -335,13 +337,13 @@ function getTrackStats(peerConnection, track, options) {
  * Get the standardized statistics for a particular MediaStreamTrack in Chrome or Safari.
  * @param {RTCPeerConnection} peerConnection
  * @param {MediaStreamTrack} track
- * @returns {Promise.<StandardizedTrackStatsReport>}
+ * @returns {Promise.<Array<StandardizedTrackStatsReport>>}
  */
 function chromeOrSafariGetTrackStats(peerConnection, track) {
   return new Promise(function(resolve, reject) {
     if (chromeMajorVersion && chromeMajorVersion < 67) {
       peerConnection.getStats(function(response) {
-        resolve(standardizeChromeLegacyStats(response, track));
+        resolve([standardizeChromeLegacyStats(response, track)]);
       }, null, reject);
       return;
     }
@@ -356,12 +358,12 @@ function chromeOrSafariGetTrackStats(peerConnection, track) {
  * @param {RTCPeerConnection} peerConnection
  * @param {MediaStreamTrack} track
  * @param {boolean} isRemote
- * @returns {Promise.<StandardizedTrackStatsReport>}
+ * @returns {Promise.<Array<StandardizedTrackStatsReport>>}
  */
 function firefoxGetTrackStats(peerConnection, track, isRemote) {
   return new Promise(function(resolve, reject) {
     peerConnection.getStats(track).then(function(response) {
-      resolve(standardizeFirefoxStats(response, isRemote));
+      resolve([standardizeFirefoxStats(response, isRemote)]);
     }, reject);
   });
 }
@@ -472,23 +474,24 @@ function consolidateRTPStats(rtpStatsArray) {
   return result;
 }
 
+
 /**
  * Standardize the MediaStreamTrack's statistics in Chrome or Safari.
  * @param {RTCStatsResponse} response
- * @returns {StandardizedTrackStatsReport}
+ * @returns {Array<StandardizedTrackStatsReport>}
  */
 function standardizeChromeOrSafariStats(response) {
-  var inbound = [];
-  var outbound = [];
-  var remoteInbound = [];
-  var remoteOutbound = [];
+  var inbound = null;
+  var outbound = []; // with simulcast enabled we could get multiple outbound-rtp entries.
+  var remoteInbound = null;
+  var remoteOutbound = null;
   var track = null;
   var codec = null;
 
   response.forEach(function(stat) {
     switch (stat.type) {
       case 'inbound-rtp':
-        inbound.push(stat);
+        inbound = stat;
         break;
       case 'outbound-rtp':
         outbound.push(stat);
@@ -500,116 +503,120 @@ function standardizeChromeOrSafariStats(response) {
         codec = stat;
         break;
       case 'remote-inbound-rtp':
-        remoteInbound.push(stat);
+        remoteInbound = stat;
         break;
       case 'remote-outbound-rtp':
-        remoteOutbound.push(stat);
+        remoteOutbound = stat;
         break;
     }
   });
 
   var isRemote = track && track.remoteSource;
-  var standardizedStats = {};
+  var mainSource = isRemote ? [inbound] : outbound;
+  var stats = [];
+  mainSource.forEach(source => {
+    var standardizedStats = {};
+    var statSources = [
+      source, // local rtp stats
+      track,
+      codec,
+      isRemote ? remoteOutbound : remoteInbound // remote rtp stats
+    ];
 
-  // setup sources to look for stat
-  var statSources = [
-    isRemote ? consolidateRTPStats(inbound) : consolidateRTPStats(outbound), // local rtp stats
-    track,
-    codec,
-    isRemote ? consolidateRTPStats(remoteOutbound) : consolidateRTPStats(remoteInbound) // remote trp stats
-  ];
+    function getStatValue(name) {
+      var sourceFound = statSources.find(function(statSource) {
+        return statSource && typeof statSource[name] !== 'undefined';
+      }) || null;
 
-  function getStatValue(name) {
-    var sourceFound = statSources.find(function(statSource) {
-      return statSource && typeof statSource[name] !== 'undefined';
-    }) || null;
-
-    return sourceFound ? sourceFound[name] : null;
-  }
-
-  var ssrc = getStatValue('ssrc');
-  if (typeof ssrc === 'number') {
-    standardizedStats.ssrc = String(ssrc);
-  }
-
-  var timestamp = getStatValue('timestamp');
-  standardizedStats.timestamp = Math.round(timestamp);
-
-  var mimeType = getStatValue('mimeType');
-  if (typeof mimeType === 'string') {
-    mimeType = mimeType.split('/');
-    standardizedStats.codecName = mimeType[mimeType.length - 1];
-  }
-
-  var roundTripTime = getStatValue('roundTripTime');
-  if (typeof roundTripTime === 'number') {
-    standardizedStats.roundTripTime = Math.round(roundTripTime * 1000);
-  }
-
-  var jitter = getStatValue('jitter');
-  if (typeof jitter === 'number') {
-    standardizedStats.jitter = Math.round(jitter * 1000);
-  }
-
-  var frameWidth = getStatValue('frameWidth');
-  if (typeof frameWidth === 'number') {
-    if (isRemote) {
-      standardizedStats.frameWidthReceived = frameWidth;
-    } else {
-      standardizedStats.frameWidthSent = frameWidth;
+      return sourceFound ? sourceFound[name] : null;
     }
-  }
 
-  var frameHeight = getStatValue('frameHeight');
-  if (typeof frameHeight === 'number') {
-    if (isRemote) {
-      standardizedStats.frameHeightReceived = frameHeight;
-    } else {
-      standardizedStats.frameHeightSent = frameHeight;
+    var ssrc = getStatValue('ssrc');
+    if (typeof ssrc === 'number') {
+      standardizedStats.ssrc = String(ssrc);
     }
-  }
 
-  var framesPerSecond = getStatValue('framesPerSecond');
-  if (typeof framesPerSecond === 'number') {
-    standardizedStats.frameRateSent = framesPerSecond;
-  }
+    var timestamp = getStatValue('timestamp');
+    standardizedStats.timestamp = Math.round(timestamp);
 
-  var bytesReceived = getStatValue('bytesReceived');
-  if (typeof bytesReceived === 'number') {
-    standardizedStats.bytesReceived = bytesReceived;
-  }
-
-  var bytesSent = getStatValue('bytesSent');
-  if (typeof bytesSent === 'number') {
-    standardizedStats.bytesSent = bytesSent;
-  }
-
-  var packetsLost = getStatValue('packetsLost');
-  if (typeof packetsLost === 'number') {
-    standardizedStats.packetsLost = packetsLost;
-  }
-
-  var packetsReceived = getStatValue('packetsReceived');
-  if (typeof packetsReceived === 'number') {
-    standardizedStats.packetsReceived = packetsReceived;
-  }
-
-  var packetsSent = getStatValue('packetsSent');
-  if (typeof packetsSent === 'number') {
-    standardizedStats.packetsSent = packetsSent;
-  }
-
-  var audioLevel = getStatValue('audioLevel');
-  if (typeof audioLevel === 'number') {
-    audioLevel = Math.round(audioLevel * CHROME_LEGACY_MAX_AUDIO_LEVEL);
-    if (isRemote) {
-      standardizedStats.audioOutputLevel = audioLevel;
-    } else {
-      standardizedStats.audioInputLevel = audioLevel;
+    var mimeType = getStatValue('mimeType');
+    if (typeof mimeType === 'string') {
+      mimeType = mimeType.split('/');
+      standardizedStats.codecName = mimeType[mimeType.length - 1];
     }
-  }
 
-  return standardizedStats;
+    var roundTripTime = getStatValue('roundTripTime');
+    if (typeof roundTripTime === 'number') {
+      standardizedStats.roundTripTime = Math.round(roundTripTime * 1000);
+    }
+
+    var jitter = getStatValue('jitter');
+    if (typeof jitter === 'number') {
+      standardizedStats.jitter = Math.round(jitter * 1000);
+    }
+
+    var frameWidth = getStatValue('frameWidth');
+    if (typeof frameWidth === 'number') {
+      if (isRemote) {
+        standardizedStats.frameWidthReceived = frameWidth;
+      } else {
+        standardizedStats.frameWidthSent = frameWidth;
+      }
+    }
+
+    var frameHeight = getStatValue('frameHeight');
+    if (typeof frameHeight === 'number') {
+      if (isRemote) {
+        standardizedStats.frameHeightReceived = frameHeight;
+      } else {
+        standardizedStats.frameHeightSent = frameHeight;
+      }
+    }
+
+    var framesPerSecond = getStatValue('framesPerSecond');
+    if (typeof framesPerSecond === 'number') {
+      standardizedStats.frameRateSent = framesPerSecond;
+    }
+
+    var bytesReceived = getStatValue('bytesReceived');
+    if (typeof bytesReceived === 'number') {
+      standardizedStats.bytesReceived = bytesReceived;
+    }
+
+    var bytesSent = getStatValue('bytesSent');
+    if (typeof bytesSent === 'number') {
+      standardizedStats.bytesSent = bytesSent;
+    }
+
+    var packetsLost = getStatValue('packetsLost');
+    if (typeof packetsLost === 'number') {
+      standardizedStats.packetsLost = packetsLost;
+    }
+
+    var packetsReceived = getStatValue('packetsReceived');
+    if (typeof packetsReceived === 'number') {
+      standardizedStats.packetsReceived = packetsReceived;
+    }
+
+    var packetsSent = getStatValue('packetsSent');
+    if (typeof packetsSent === 'number') {
+      standardizedStats.packetsSent = packetsSent;
+    }
+
+    var audioLevel = getStatValue('audioLevel');
+    if (typeof audioLevel === 'number') {
+      audioLevel = Math.round(audioLevel * CHROME_LEGACY_MAX_AUDIO_LEVEL);
+      if (isRemote) {
+        standardizedStats.audioOutputLevel = audioLevel;
+      } else {
+        standardizedStats.audioInputLevel = audioLevel;
+      }
+    }
+
+    stats.push(standardizedStats);
+  });
+
+  return stats;
 }
 
 /**

--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -479,15 +479,17 @@ function standardizeChromeOrSafariStats(response) {
   });
 
   var isRemote = track && track.remoteSource;
-  var mainSource = isRemote ? [inbound] : outbound;
+  var mainSources = isRemote ? [inbound] : outbound;
   var stats = [];
-  mainSource.forEach(source => {
+  var remoteSource = isRemote ? remoteOutbound : remoteInbound; // remote rtp stats
+
+  mainSources.forEach(source => {
     var standardizedStats = {};
     var statSources = [
       source, // local rtp stats
       track,
       codec,
-      isRemote ? remoteOutbound : remoteInbound // remote rtp stats
+      remoteSource && remoteSource.ssrc === source.ssrc ? remoteSource : null, // remote rtp stats
     ];
 
     function getStatValue(name) {

--- a/test/unit/spec/getstats.js
+++ b/test/unit/spec/getstats.js
@@ -243,7 +243,7 @@ describe('getStats', function() {
       });
   });
 
-  it('should resolve the promise with a StandardizedStatsResponse in Chrome simulcast scenario (outbound) ', () => {
+  it('should resolve the returned Promise with a StandardizedStatsResponse for VP8 simulcast scenario (outbound)', () => {
     var options = {
       chromeFakeStats: new Map(Object.entries({
         RTCOutboundRTPVideoStream_4003256843: {


### PR DESCRIPTION
when simulcast is enabled on chrome 84 returns multiple outbound-rtp stats for the given track. Previously we were just returning stats from last outbound-rtp stats found. This change consolidates the stats for bytesSent, packetsSent, packetsLost 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
