### PR TITLE
add missing dependencies for browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,9 @@
     "simple-git": "^2.4.0",
     "watchify": "^3.9.0",
     "webrtc-adapter": "^6.4.8"
+  },
+  "dependencies": {
+    "events": "^3.2.0",
+    "util": "^0.12.3"
   }
 }


### PR DESCRIPTION
If this package is intended to be used in browsers it should not require node builtins.

Instead it should use browser compatible dependencies, e.g.:

- https://www.npmjs.com/package/util
- https://www.npmjs.com/package/events

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
