### PR TITLE
Add support for iOS applications serving a webpage inside WKWebView 

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -129,7 +129,7 @@ function guessBrowser(userAgent) {
   if (/Firefox|FxiOS/.test(userAgent)) {
     return 'firefox';
   }
-  if (/Safari|iPhone/.test(userAgent)) {
+  if (/Safari|iPhone|iPad/.test(userAgent)) {
     return 'safari';
   }
   return null;

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -129,7 +129,7 @@ function guessBrowser(userAgent) {
   if (/Firefox|FxiOS/.test(userAgent)) {
     return 'firefox';
   }
-  if (/Safari/.test(userAgent)) {
+  if (/Safari|iPhone/.test(userAgent)) {
     return 'safari';
   }
   return null;

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -32,6 +32,11 @@ describe('Util', () => {
         'safari'
       ],
       [
+        'Safari WKWebView',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+        'safari'
+      ],
+      [
         'Edge Desktop (Chromium)',
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edg/15.15063',
         'chrome'

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -32,8 +32,13 @@ describe('Util', () => {
         'safari'
       ],
       [
-        'Safari WKWebView',
+        'Safari WKWebView - iPhone',
         'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
+        'safari'
+      ],
+      [
+        'Safari WKWebView - iPad',
+        'Mozilla/5.0 (iPad; CPU OS 14_4 like Mac OS X) AppleWebkit/605.1.15 (KHTML, like Gecko) Mobile/15E148',
         'safari'
       ],
       [


### PR DESCRIPTION

Solves an issue in the twilio-video library: [https://github.com/twilio/twilio-video.js/issues/1364](https://github.com/twilio/twilio-video.js/issues/1364)

The following error is caused by [getSdpFormat()](https://github.com/twilio/twilio-webrtc.js/blob/3081a11ad9d2be748df1fc07a96e51ac649b773e/lib/util/sdp.js#L89) which is not able to guess the browser if a webpage is rendered inside WKWebView in an iOS application.
```
Calling setRemoteDescription with an RTCSessionDescription of type "answer" failed with the error "Failed to set remote answer sdp: The order of m-lines in answer doesn't match order in offer. Rejecting answer.
```

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
