### PR TITLE
expose timestamp for active candidate pair stats report

### DIFF
--- a/lib/getstats.js
+++ b/lib/getstats.js
@@ -168,7 +168,8 @@ function standardizeChromeOrSafariActiveIceCandidatePairStats(stats) {
     { key: 'state', type: 'string', fixup: function(state) { return state === 'inprogress' ? 'in-progress' : state; } },
     { key: 'totalRoundTripTime', type: 'number' },
     { key: 'transportId', type: 'string' },
-    { key: 'writable', type: 'boolean' }
+    { key: 'writable', type: 'boolean' },
+    { key: 'timestamp', type: 'number' }
   ].reduce(function(report, keyInfo) {
     report[keyInfo.key] = typeof activeCandidatePairStats[keyInfo.key] === keyInfo.type
       ? (keyInfo.fixup ? keyInfo.fixup(activeCandidatePairStats[keyInfo.key]) : activeCandidatePairStats[keyInfo.key])


### PR DESCRIPTION
This change adds a `timestamp` field. This is used for preflight stats.  
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
