### PR TITLE
Adding in new Regex for iOS Chrome support

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -142,8 +142,11 @@ function guessBrowser(userAgent) {
   if (typeof userAgent === 'undefined') {
     userAgent = getUserAgent();
   }
-  if (/Chrome|CriOS/.test(userAgent)) {
+  if (/Chrome/.test(userAgent)) {
     return 'chrome';
+  }
+  if (/(?=.*CriOS)(?=.*Mobi)/.test(userAgent)) {
+    return 'CriOS';
   }
   if (/Firefox|FxiOS/.test(userAgent)) {
     return 'firefox';

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -3,8 +3,8 @@
 var assert = require('assert');
 var util = require('../../../../lib/util');
 
-describe.only('Util', () => {
-  describe.only('guessBrowser', () => {
+describe('Util', () => {
+  describe('guessBrowser', () => {
     [
       [
         'Chrome Desktop',

--- a/test/unit/spec/util/index.js
+++ b/test/unit/spec/util/index.js
@@ -3,8 +3,8 @@
 var assert = require('assert');
 var util = require('../../../../lib/util');
 
-describe('Util', () => {
-  describe('guessBrowser', () => {
+describe.only('Util', () => {
+  describe.only('guessBrowser', () => {
     [
       [
         'Chrome Desktop',
@@ -14,7 +14,7 @@ describe('Util', () => {
       [
         'Chrome iOS',
         'Mozilla/5.0 (iPad; CPU OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/79.0.3945.73 Mobile/15E148 Safari/604.1',
-        'chrome'
+        'CriOS'
       ],
       [
         'Firefox Desktop',
@@ -39,7 +39,7 @@ describe('Util', () => {
     ].forEach(([browser, userAgent, name]) => {
       context(`${browser} - ${userAgent}`, () => {
         it(`should return "${name}"`, () => {
-          assert.equal(util.guessBrowser(userAgent), name);
+        assert.strictEqual(util.guessBrowser(userAgent), name);
         });
       });
     });


### PR DESCRIPTION
JIRA: [VIDEO-5021](https://issues.corp.twilio.com/browse/VIDEO-5921)

Adding in support for iOS Chrome in our `guessBrowser` function. @makarandp0 I know you mentioned that when iOS chrome pretends to be desktop(?), we can't detect it. But I've added this so we can narrow down the pool so we are not applying the two workarounds for all of chrome and just for those on chrome and on iOS.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
