### PR TITLE
addTransceiver for iOS Chrome

### DIFF
--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -9,6 +9,7 @@ var MediaStream = require('../mediastream');
 var RTCRtpSenderShim = require('../rtcrtpsender');
 var sdpUtils = require('../util/sdp');
 var util = require('../util');
+var isIOSChrome = require('../util').isIOSChrome;
 
 var isUnifiedPlan = sdpUtils.getSdpFormat() === 'unified';
 
@@ -288,26 +289,28 @@ ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {
   var options = (args.length > 1 ? args[2] : args[0]) || {};
   var self = this;
 
-  // NOTE (joma): From SafariRTCPeerConnection in order to support iOS Chrome.
-  if (!this._audioTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'audio'))) {
-    delete options.offerToReceiveAudio;
-    try {
-      this._audioTransceiver = isUnifiedPlan
-        ? this.addTransceiver('audio', { direction: 'recvonly' })
-        : this.addTransceiver('audio');
-    } catch (e) {
-      return Promise.reject(e);
+  if (isIOSChrome()) {
+    // NOTE (joma): From SafariRTCPeerConnection in order to support iOS Chrome.
+    if (options.offerToReceiveVideo && !this._audioTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'audio'))) {
+      delete options.offerToReceiveAudio;
+      try {
+        this._audioTransceiver = isUnifiedPlan
+          ? this.addTransceiver('audio', { direction: 'recvonly' })
+          : this.addTransceiver('audio');
+      } catch (e) {
+        return Promise.reject(e);
+      }
     }
-  }
 
-  if (!this._videoTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'video'))) {
-    delete options.offerToReceiveVideo;
-    try {
-      this._videoTransceiver = isUnifiedPlan
-        ? this.addTransceiver('video', { direction: 'recvonly' })
-        : this.addTransceiver('video');
-    } catch (e) {
-      return Promise.reject(e);
+    if (options.offerToReceiveVideo && !this._videoTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'video'))) {
+      delete options.offerToReceiveVideo;
+      try {
+        this._videoTransceiver = isUnifiedPlan
+          ? this.addTransceiver('video', { direction: 'recvonly' })
+          : this.addTransceiver('video');
+      } catch (e) {
+        return Promise.reject(e);
+      }
     }
   }
 

--- a/lib/rtcpeerconnection/chrome.js
+++ b/lib/rtcpeerconnection/chrome.js
@@ -10,6 +10,8 @@ var RTCRtpSenderShim = require('../rtcrtpsender');
 var sdpUtils = require('../util/sdp');
 var util = require('../util');
 
+var isUnifiedPlan = sdpUtils.getSdpFormat() === 'unified';
+
 // NOTE(mroberts): This class wraps Chrome's RTCPeerConnection implementation.
 // It provides some functionality not currently present in Chrome, namely the
 // abilities to
@@ -286,6 +288,29 @@ ChromeRTCPeerConnection.prototype.createOffer = function createOffer() {
   var options = (args.length > 1 ? args[2] : args[0]) || {};
   var self = this;
 
+  // NOTE (joma): From SafariRTCPeerConnection in order to support iOS Chrome.
+  if (!this._audioTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'audio'))) {
+    delete options.offerToReceiveAudio;
+    try {
+      this._audioTransceiver = isUnifiedPlan
+        ? this.addTransceiver('audio', { direction: 'recvonly' })
+        : this.addTransceiver('audio');
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  }
+
+  if (!this._videoTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'video'))) {
+    delete options.offerToReceiveVideo;
+    try {
+      this._videoTransceiver = isUnifiedPlan
+        ? this.addTransceiver('video', { direction: 'recvonly' })
+        : this.addTransceiver('video');
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  }
+
   var promise = this._peerConnection.createOffer(options).then(function(offer) {
     // NOTE(mmalavalli): If createOffer() is called immediately after rolling back, then we no
     // longer need to retain the rolled back tracks to SSRCs Map.
@@ -438,6 +463,19 @@ function setRemoteAnswer(peerConnection, answer) {
     // and the underlying RTCPeerConnection implementation have converged. We
     // can unblock any pending calls to addIceCandidate now.
     peerConnection._signalingStateLatch.lower();
+  });
+}
+
+/**
+ * Whether a ChromeRTCPeerConnection has any RTCRtpReceivers(s) for the given
+ * MediaStreamTrack kind.
+ * @param {ChromeRTCPeerConnection} peerConnection
+ * @param {'audio' | 'video'} kind
+ * @returns {boolean}
+ */
+ function hasReceiversForTracksOfKind(peerConnection, kind) {
+  return !!peerConnection.getTransceivers().find(function(transceiver) {
+    return transceiver.receiver && transceiver.receiver.track && transceiver.receiver.track.kind === kind;
   });
 }
 

--- a/lib/rtcpeerconnection/safari.js
+++ b/lib/rtcpeerconnection/safari.js
@@ -161,7 +161,7 @@ SafariRTCPeerConnection.prototype.createOffer = function createOffer(options) {
 
   // NOTE(mroberts): In general, this is not the way to do this; however, it's
   // good enough for our application.
-  if (options.offerToReceiveAudio && !this._audioTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'audio'))) {
+  if (!this._audioTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'audio'))) {
     delete options.offerToReceiveAudio;
     try {
       this._audioTransceiver = isUnifiedPlan
@@ -172,7 +172,7 @@ SafariRTCPeerConnection.prototype.createOffer = function createOffer(options) {
     }
   }
 
-  if (options.offerToReceiveVideo && !this._videoTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'video'))) {
+  if (!this._videoTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'video'))) {
     delete options.offerToReceiveVideo;
     try {
       this._videoTransceiver = isUnifiedPlan

--- a/lib/rtcpeerconnection/safari.js
+++ b/lib/rtcpeerconnection/safari.js
@@ -161,7 +161,7 @@ SafariRTCPeerConnection.prototype.createOffer = function createOffer(options) {
 
   // NOTE(mroberts): In general, this is not the way to do this; however, it's
   // good enough for our application.
-  if (!this._audioTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'audio'))) {
+  if (options.offerToReceiveVideo && !this._audioTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'audio'))) {
     delete options.offerToReceiveAudio;
     try {
       this._audioTransceiver = isUnifiedPlan
@@ -172,7 +172,7 @@ SafariRTCPeerConnection.prototype.createOffer = function createOffer(options) {
     }
   }
 
-  if (!this._videoTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'video'))) {
+  if (options.offerToReceiveVideo && !this._videoTransceiver && !(isUnifiedPlan && hasReceiversForTracksOfKind(this, 'video'))) {
     delete options.offerToReceiveVideo;
     try {
       this._videoTransceiver = isUnifiedPlan

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -186,6 +186,18 @@ function guessBrowserVersion(userAgent) {
 }
 
 /**
+ * Check whether the current browser is iOS Chrome.
+ * @param {string} [userAgent=navigator.userAgent]
+ * @returns {boolean}
+ */
+function isIOSChrome(userAgent) {
+  if (typeof userAgent === 'undefined') {
+    userAgent = getUserAgent();
+  }
+  return (/Mobi/.test(userAgent) && guessBrowser() === 'chrome' && /iPad|iPhone|iPod/.test(userAgent));
+}
+
+/**
  * Intercept an event that might otherwise be proxied on an EventTarget.
  * @param {EventTarget} target
  * @param {string} type
@@ -315,6 +327,7 @@ exports.difference = difference;
 exports.flatMap = flatMap;
 exports.guessBrowser = guessBrowser;
 exports.guessBrowserVersion = guessBrowserVersion;
+exports.isIOSChrome = isIOSChrome;
 exports.interceptEvent = interceptEvent;
 exports.legacyPromise = legacyPromise;
 exports.makeUUID = makeUUID;


### PR DESCRIPTION
Small PR which addresses iOS Chrome's inability to subscribe to a track. I've simply moved over what we currently have implemented for Safari into the chrome tab as well as removed some of the legacy properties we looked at which are not supported by Safari.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
